### PR TITLE
Feature/generic cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ Thumbs.db
 *.mov
 *.wmv
 
+# Local directories
+.etc/

--- a/catkin_workspace.vcs
+++ b/catkin_workspace.vcs
@@ -1,0 +1,21 @@
+repositories:
+  elevation_mapping:
+    type: git
+    url: https://github.com/leggedrobotics/elevation_mapping.git
+    version: master
+  gtsam_catkin:
+    type: git
+    url: https://github.com/leggedrobotics/gtsam_catkin.git
+    version: main
+  holistic_fusion:
+    type: git
+    url: git@github.com:leggedrobotics/holistic_fusion.git
+    version: feature/docker
+  kindr:
+    type: git
+    url: https://github.com/leggedrobotics/kindr.git
+    version: master
+  kindr_ros:
+    type: git
+    url: https://github.com/leggedrobotics/kindr_ros.git
+    version: master

--- a/docker/bin/attach_to_latest_container.sh
+++ b/docker/bin/attach_to_latest_container.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#=============================================================================
+# Copyright (C) 2025, Robotic Systems Lab, ETH Zurich
+# All rights reserved.
+# http://www.rsl.ethz.ch
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# Authors: Julian Nubert, nubertj@ethz.ch
+#          Lorenzo Terenzi, lterenzi@ethz.ch
+#=============================================================================
+
+LATEST_CONTAINER_NAME=$(docker ps --latest --format "{{.Names}}")
+echo "Name of latest docker container is $LATEST_CONTAINER_NAME. Attaching to it..."
+docker exec -it $LATEST_CONTAINER_NAME /entrypoint.sh

--- a/docker/bin/run_ros1_noetic_image.sh
+++ b/docker/bin/run_ros1_noetic_image.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+#=============================================================================
+# Copyright (C) 2025, Robotic Systems Lab, ETH Zurich
+# All rights reserved.
+# http://www.rsl.ethz.ch
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# Authors: Julian Nubert, nubertj@ethz.ch
+#          Lorenzo Terenzi, lterenzi@ethz.ch
+#=============================================================================
+
+# Exits if error occurs
+set -e
+
+# Image name
+IMAGE="rslethz/holistic_fusion_ros1:latest"
+
+# Entry point
+ENTRYPOINT="/entrypoint.sh"
+
+# Graphical output
+XSOCK=/tmp/.X11-unix
+XAUTH=/tmp/.docker.xauth
+
+# Create symlinks to user configs within the build context.
+mkdir -p .etc && cd .etc
+ln -sf /etc/passwd .
+ln -sf /etc/shadow .
+ln -sf /etc/group .
+cd ..
+
+# Launch a container from the prebuilt image.
+echo -e "[run.sh]: \e[1;32mRunning docker image '$IMAGE' with entrypoint $ENTRYPOINT.\e[0m"
+echo "---------------------"
+RUN_COMMAND="docker run \
+  $ARGS \
+  -v /lib/modules:/lib/modules \
+  --volume=$XSOCK:$XSOCK:rw \
+  --volume=$XAUTH:$XAUTH:rw \
+  --env="QT_X11_NO_MITSHM=1" \
+  --env="XAUTHORITY=$XAUTH" \
+  --env="DISPLAY=$DISPLAY" \
+  --cap-add=ALL \
+  --privileged \
+  --net=host \
+  -eHOST_USERNAME=$(whoami) \
+  -v$HOME:$HOME \
+  -v$(pwd)/.etc/shadow:/etc/shadow \
+  -v$(pwd)/.etc/passwd:/etc/passwd \
+  -v$(pwd)/.etc/group:/etc/group \
+  -v/etc/localtime:/etc/localtime:ro \
+  --entrypoint=$ENTRYPOINT
+  --shm-size=2gb
+  -it $IMAGE"
+
+# Final command
+echo -e "[run.sh]: \e[1;32mThe final run command is\n\e[0;35m$RUN_COMMAND\e[0m."
+$RUN_COMMAND
+
+# EOF

--- a/docker/ros1_noetic/README.md
+++ b/docker/ros1_noetic/README.md
@@ -1,0 +1,13 @@
+# Docker Setup for Holistic Fusion
+
+We provide docker images for running Holistic Fusion in a controlled environment.
+The ROS1 Image is based on Ubuntu 20.04 and includes the necessary dependencies for running Holistic Fusion.
+The ROS2 Image is based on Ubuntu 22.04 and will be released in the future.
+
+## ROS1 Noetic Image
+
+To build the ROS1 Noetic image, run the following command from the root of the repository:
+
+```bash
+docker/bin/build_ros1_noetic_image.sh
+```

--- a/docker/ros1_noetic/base.Dockerfile
+++ b/docker/ros1_noetic/base.Dockerfile
@@ -1,0 +1,79 @@
+#=============================================================================
+# Copyright (C) 2025, Robotic Systems Lab, ETH Zurich
+# All rights reserved.
+# http://www.rsl.ethz.ch
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# Authors: Julian Nubert, nubertj@ethz.ch
+#          Lorenzo Terenzi, lterenzi@ethz.ch
+#=============================================================================
+
+#==
+# Foundation
+#==
+ARG UBUNTU_VERSION=20.04
+FROM ubuntu:${UBUNTU_VERSION}
+
+# Suppresses interactive calls to APT
+ENV DEBIAN_FRONTEND="noninteractive"
+
+# Updates
+RUN apt update && apt upgrade -y
+
+# ----------------------------------------------------------------------------
+
+#==
+# System APT base dependencies and utilities
+#==
+
+COPY submodules/base.sh /home/base.sh
+RUN chmod +x /home/base.sh
+RUN /home/base.sh && rm /home/base.sh
+
+#==
+# ROS
+#==
+
+# Version
+ARG ROS=noetic
+
+COPY submodules/ros_1.sh /home/ros_1.sh
+RUN chmod +x /home/ros_1.sh
+RUN /home/ros_1.sh && rm /home/ros_1.sh
+
+#==
+# GTSAM
+#==
+
+COPY submodules/gtsam.sh /home/gtsam.sh
+RUN chmod +x /home/gtsam.sh
+RUN /home/gtsam.sh && rm /home/gtsam.sh
+
+# ----------------------------------------------------------------------------
+
+#==
+# Permissions
+#==
+RUN chmod ugo+rwx /software
+
+#==
+# Environment
+#==
+COPY ros1_noetic/bashrc /etc/bash.bashrc
+RUN chmod a+rwx /etc/bash.bashrc
+
+# ----------------------------------------------------------------------------
+
+#==
+# Execution
+#==
+
+COPY ros1_noetic/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+#ENTRYPOINT ["/entrypoint.sh"]
+CMD []
+
+# EOF

--- a/docker/ros1_noetic/bashrc
+++ b/docker/ros1_noetic/bashrc
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+#=============================================================================
+# Copyright (C) 2025, Robotic Systems Lab, ETH Zurich
+# All rights reserved.
+# http://www.rsl.ethz.ch
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# Authors: Julian Nubert, nubertj@ethz.ch
+#          Lorenzo Terenzi, lterenzi@ethz.ch
+#=============================================================================
+
+# If not running interactively, don't do anything
+case $- in
+    *i*) ;;
+      *) return;;
+esac
+
+# don't put duplicate lines or lines starting with space in the history.
+HISTCONTROL=ignoreboth
+
+# append to the history file, don't overwrite it
+shopt -s histappend
+
+# for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
+HISTSIZE=1000
+HISTFILESIZE=2000
+
+# check the window size after each command and, if necessary,
+# update the values of LINES and COLUMNS.
+shopt -s checkwinsize
+
+# make less more friendly for non-text input files, see lesspipe(1)
+[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+# set a fancy prompt (non-color, unless we know we "want" color)
+case "$TERM" in
+    xterm-color|*-256color) color_prompt=yes;;
+esac
+
+# uncomment for a colored prompt, if the terminal has the capability; turned
+# off by default to not distract the user: the focus in a terminal window
+# should be on the output of commands, not on the prompt
+#force_color_prompt=yes
+
+if [ -n "$force_color_prompt" ]; then
+    if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
+	# We have color support; assume it's compliant with Ecma-48
+	# (ISO/IEC-6429). (Lack of such support is extremely rare, and such
+	# a case would tend to support setf rather than setaf.)
+	color_prompt=yes
+    else
+	color_prompt=
+    fi
+fi
+
+if [ "$color_prompt" = yes ]; then
+    PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+else
+    PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
+fi
+unset color_prompt force_color_prompt
+
+# If this is an xterm set the title to user@host:dir
+case "$TERM" in
+xterm*|rxvt*)
+    PS1="\[\e]0;${debian_chroot:+($debian_chroot)}\u@\h: \w\a\]$PS1"
+    ;;
+*)
+    ;;
+esac
+
+# enable color support of ls and also add handy aliases
+if [ -x /usr/bin/dircolors ]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+    alias ls='ls --color=auto'
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+fi
+
+# some more ls aliases
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+# Add an "alert" alias for long running commands.  Use like so:
+#   sleep 10; alert
+alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo error)" "$(history|tail -n1|sed -e '\''s/^\s*[0-9]\+\s*//;s/[;&|]\s*alert$//'\'')"'
+
+# Alias definitions.
+if [ -f ~/.bash_aliases ]; then
+    . ~/.bash_aliases
+fi
+
+# enable programmable completion features (you don't need to enable
+# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
+# sources /etc/bash.bashrc).
+if ! shopt -oq posix; then
+  if [ -f /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+  elif [ -f /etc/bash_completion ]; then
+    . /etc/bash_completion
+  fi
+fi
+
+#==
+# Fuzzy search
+#==
+# Install fuzzy-search if missing
+if [[ ! -d ~/.fzf ]]
+then
+    git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf && ~/.fzf/install
+fi
+
+# Enable fuzzy search in terminal
+[ -f ~/.fzf.bash ] && source ~/.fzf.bash
+
+#==
+# Git
+#==
+parse_git_branch() {
+     git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/(\1)/'
+}
+export PS1=$PS1"\[\e[91m\]\$(parse_git_branch)\[\e[00m\]$ "
+export PS1="(D) "$PS1
+
+#==
+# ROS
+#==
+# Source the ROS distribution file to configure the shell environment.
+FILE=/opt/ros/noetic/setup.bash
+if test -f "$FILE"; 
+then
+    echo "$FILE exists. Therefore sourcing noetic."
+    source $FILE
+else
+    echo "$FILE does not exist. Therefore not sourcing noetic."
+fi
+
+# EOF

--- a/docker/ros1_noetic/entrypoint.sh
+++ b/docker/ros1_noetic/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#=============================================================================
+# Copyright (C) 2025, Robotic Systems Lab, ETH Zurich
+# All rights reserved.
+# http://www.rsl.ethz.ch
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# Authors: Vassilios Tsounis, tsounisv@ethz.ch
+#          Julian Nubert, nubertj@ethz.ch
+#=============================================================================
+figlet m545
+#==
+# Log into the container as the host user
+#==
+# set home for host user
+export HOME=/home/$HOST_USERNAME
+export USER=$HOST_USERNAME
+cd $HOME
+
+# Enable sudo access without password
+echo "root ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+echo "$HOST_USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Proceed as host user with superuser permissions
+sudo -E -u $HOST_USERNAME bash --rcfile /etc/bash.bashrc
+
+# EOF

--- a/docker/submodules/base.sh
+++ b/docker/submodules/base.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+apt update && apt install -y \
+  sudo \
+  tzdata \
+  lsb-release \
+  ca-certificates \
+  apt-utils \
+  gnupg2 \
+  locate \
+  curl \
+  wget \
+  git \
+  vim \
+  gedit \
+  tmux \
+  unzip \
+  iputils-ping \
+  net-tools \
+  htop \
+  iotop \
+  iftop \
+  nmap \
+  software-properties-common \
+  build-essential \
+  gdb \
+  pkg-config \
+  cmake \
+  zsh \
+  clang-format \
+  clang-tidy \
+  xterm \
+  gnome-terminal \
+  dialog \
+  tasksel \
+  meld \
+  figlet \
+  && \
+  rm -rf /var/lib/apt/lists/*

--- a/docker/submodules/gtsam.sh
+++ b/docker/submodules/gtsam.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+mkdir -p /software \
+ && cd /software \
+ && git clone https://github.com/borglab/gtsam.git \
+ && mkdir -p /software/gtsam/build \
+ && cd /software/gtsam/build \
+ && git checkout 4.2 \
+ && cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF \
+    -DGTSAM_POSE3_EXPMAP=ON \
+    -DGTSAM_ROT3_EXPMAP=ON \
+    -DGTSAM_USE_QUATERNIONS=ON \
+    -DGTSAM_USE_SYSTEM_EIGEN=ON \
+    /software/gtsam \
+ && make install -j$(nproc)

--- a/docker/submodules/ros_1.sh
+++ b/docker/submodules/ros_1.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list' \
+ && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add - \
+ && apt update && apt install -y \
+  python3-pip \
+  python3-rosdep \
+  python3-rosclean \
+  python3-rosparam \
+  python3-progressbar \
+  python3-catkin-tools \
+  python3-osrf-pycommon \
+  python3-virtualenvwrapper \
+  ros-${ROS}-desktop-full \
+  ros-${ROS}-velodyne-pointcloud \
+  ros-${ROS}-joy \
+  ros-${ROS}-grid-map-core \
+  ros-${ROS}-grid-map \
+ && rm -rf /var/lib/apt/lists/* \
+ && rosdep init && rosdep update \
+ && apt update && apt install -y \
+  libblas-dev \
+  xutils-dev \
+  gfortran \
+  libf2c2-dev \
+  libgmock-dev \
+  libgoogle-glog-dev \
+  libboost-all-dev \
+  libeigen3-dev \
+  libglpk-dev \
+  liburdfdom-dev \
+  liboctomap-dev \
+  libassimp-dev \
+  python3-catkin-tools \
+  python3-pytest \
+  python3-lxml \
+  ros-${ROS}-ompl \
+  ros-${ROS}-octomap-msgs \
+  ros-${ROS}-pybind11-catkin \
+  doxygen-latex \
+  usbutils \
+  python3-vcstool \
+ && rm -rf /var/lib/apt/lists/* \
+ && sudo ln -s /usr/include/eigen3 /usr/local/include/

--- a/examples/ros/anymal_estimator_graph/CMakeLists.txt
+++ b/examples/ros/anymal_estimator_graph/CMakeLists.txt
@@ -21,14 +21,6 @@ if (NOT WIN32)
     set(Magenta "${Esc}[35m")
 endif ()
 
-# March native check
-#include(CheckCXXCompilerFlag)
-#CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
-#if(COMPILER_SUPPORTS_MARCH_NATIVE)
-#  add_compile_options("-march=native")
-#  message("${BoldMagenta}INFO: Using -march=native${ColourReset}")
-#endif()
-
 # Catkin dependencies -------------------------------------------------------------------------------------------------
 set(CATKIN_PACKAGE_DEPENDENCIES
         graph_msf_ros
@@ -41,12 +33,14 @@ set(CATKIN_PACKAGE_DEPENDENCIES
         graph_msf_anymal_msgs
 )
 
+# CMAKE dependencies --------------------------------------------------------------------------------
 find_package(catkin REQUIRED COMPONENTS
         ${CATKIN_PACKAGE_DEPENDENCIES}
 )
 
 find_package(Glog REQUIRED)
 
+# Catkin Package
 catkin_package(
         INCLUDE_DIRS include
         LIBRARIES ${PROJECT_NAME}
@@ -104,6 +98,7 @@ endif (cmake_clang_tools_FOUND AND NOT DEFINED NO_CLANG_TOOLING)
 #############
 ## Install ##
 #############
+
 install(TARGETS ${PROJECT_NAME}
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/graph_msf/CMakeLists.txt
+++ b/graph_msf/CMakeLists.txt
@@ -73,7 +73,7 @@ add_library(${PROJECT_NAME} SHARED
 target_link_libraries(${PROJECT_NAME}
         gtsam
         gtsam_unstable
-        libmetis-gtsam.so
+        metis-gtsam
 )
 
 # Add clang tooling

--- a/graph_msf/CMakeLists.txt
+++ b/graph_msf/CMakeLists.txt
@@ -17,29 +17,10 @@ if (NOT WIN32)
     set(Magenta "${Esc}[35m")
 endif ()
 
-# March native check
-#include(CheckCXXCompilerFlag)
-#CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
-#if(COMPILER_SUPPORTS_MARCH_NATIVE)
-#    add_compile_options("-march=native")
-#    message("${BoldMagenta}INFO: Using -march=native${ColourReset}")
-#endif()
-
-# Catkin
-set(CATKIN_PACKAGE_DEPENDENCIES
-        gtsam_catkin
-)
-
-find_package(catkin REQUIRED COMPONENTS
-        ${CATKIN_PACKAGE_DEPENDENCIES}
-)
-
-catkin_package(
-        CATKIN_DEPENDS ${CATKIN_PACKAGE_DEPENDENCIES}
-        DEPENDS
-        INCLUDE_DIRS include
-        LIBRARIES ${PROJECT_NAME}
-)
+# Eigen
+find_package(Eigen3 REQUIRED COMPONENTS)
+# GTSAM
+find_package(GTSAM REQUIRED)
 
 ###########
 ## Build ##
@@ -49,10 +30,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include_directories(
         include
-        ${catkin_INCLUDE_DIRS}
         ${EIGEN3_INCLUDE_DIR}
-        #        ${GTSAM_INCLUDE_DIR}
-        ${Python3_INCLUDE_DIRS}
+        ${GTSAM_INCLUDE_DIR}
 )
 
 add_library(${PROJECT_NAME}
@@ -71,9 +50,10 @@ add_library(${PROJECT_NAME}
         src/lib/NavState.cpp
 )
 
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
-
-add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(${PROJECT_NAME}
+        ${catkin_LIBRARIES}
+        ${GTSAM_LIBRARIES}
+)
 
 # Add clang tooling
 find_package(cmake_clang_tools QUIET)
@@ -91,11 +71,11 @@ endif (cmake_clang_tools_FOUND AND NOT DEFINED NO_CLANG_TOOLING)
 #############
 
 install(TARGETS ${PROJECT_NAME}
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 install(DIRECTORY include/${PROJECT_NAME}/
-        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
 )

--- a/graph_msf/CMakeLists.txt
+++ b/graph_msf/CMakeLists.txt
@@ -1,8 +1,24 @@
 cmake_minimum_required(VERSION 3.16)
 project(graph_msf)
 
+message("Building graph_msf library -----------------------------")
+
 ## Compile as C++17, supported in ROS Noetic and newer
 add_compile_options(-std=c++17)
+
+# If build variables not set, set them to default values
+if (NOT DEFINED CMAKE_BUILD_LIBDIR)
+    set(CMAKE_BUILD_LIBDIR ${CMAKE_BINARY_DIR}/lib)
+endif ()
+if (NOT DEFINED CMAKE_BUILD_BINDIR)
+    set(CMAKE_BUILD_BINDIR ${CMAKE_BINARY_DIR}/bin)
+endif ()
+if (NOT DEFINED CMAKE_BUILD_INCLUDE_DIR)
+    set(CMAKE_BUILD_INCLUDE_DIR ${CMAKE_BINARY_DIR}/include)
+endif ()
+message("CMAKE_BUILD_LIBDIR: ${CMAKE_BUILD_LIBDIR}")
+message("CMAKE_BUILD_BINDIR: ${CMAKE_BUILD_BINDIR}")
+message("CMAKE_BUILD_INCLUDE_DIR: ${CMAKE_BUILD_INCLUDE_DIR}")
 
 # Find dependencies ----------------------------------------------------------------------------------------------------
 find_package(Eigen3 REQUIRED)
@@ -21,6 +37,9 @@ endif ()
 find_package(Eigen3 REQUIRED COMPONENTS)
 # GTSAM
 find_package(GTSAM REQUIRED)
+find_package(GTSAM_UNSTABLE REQUIRED)
+message("GTSAM Version:" ${GTSAM_VERSION})
+message("GTSAM Path:" ${GTSAM_DIR})
 
 ###########
 ## Build ##
@@ -34,7 +53,7 @@ include_directories(
         ${GTSAM_INCLUDE_DIR}
 )
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
         src/lib/eigen_wrapped_gtsam_utils.cpp
         src/lib/FileLogger.cpp
         src/lib/GraphMsf.cpp
@@ -50,9 +69,11 @@ add_library(${PROJECT_NAME}
         src/lib/NavState.cpp
 )
 
+# Link GTSAM and other dependencies to the graph_msf library
 target_link_libraries(${PROJECT_NAME}
-        ${catkin_LIBRARIES}
-        ${GTSAM_LIBRARIES}
+        gtsam
+        gtsam_unstable
+        libmetis-gtsam.so
 )
 
 # Add clang tooling
@@ -70,12 +91,30 @@ endif (cmake_clang_tools_FOUND AND NOT DEFINED NO_CLANG_TOOLING)
 ## Install ##
 #############
 
+# Export the include directories and linked libraries
 install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}-targets  # Export the target for downstream usage
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
+# Install the export file for downstream projects
+install(EXPORT ${PROJECT_NAME}-targets
+        FILE ${PROJECT_NAME}Config.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
+
+# Install the include directory
 install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
 )
+
+# Add GTSAM include directories to the exported interface
+target_include_directories(${PROJECT_NAME} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+    ${EIGEN3_INCLUDE_DIR}
+)
+
+message("Finished building graph_msf library -----------------------------")

--- a/graph_msf/package.xml
+++ b/graph_msf/package.xml
@@ -12,14 +12,11 @@
     <license>BSD</license>
     <author email="nubertj@ethz.ch">Julian Nubert</author>
 
-    <buildtool_depend>catkin</buildtool_depend>
     <build_depend>cmake_clang_tools</build_depend>
     <build_depend>Eigen3</build_depend>
     <build_depend>GTSAM</build_depend>
-    <build_depend>gtsam_catkin</build_depend>
 
     <exec_depend>Eigen3</exec_depend>
     <exec_depend>GTSAM</exec_depend>
-    <exec_depend>gtsam_catkin</exec_depend>
 
 </package>

--- a/ros/graph_msf_catkin/.gitignore
+++ b/ros/graph_msf_catkin/.gitignore
@@ -1,0 +1,3 @@
+# Temp
+tmp/
+src/

--- a/ros/graph_msf_catkin/CMakeLists.txt
+++ b/ros/graph_msf_catkin/CMakeLists.txt
@@ -1,15 +1,18 @@
 cmake_minimum_required(VERSION 3.10)
 project(graph_msf_catkin)
 
+## Compile as C++17, supported in ROS Noetic and newer
+add_compile_options(-std=c++17)
+
 find_package(catkin REQUIRED)
 
 # Color
-if (NOT WIN32)
+if(NOT WIN32)
     string(ASCII 27 Esc)
     set(ColourReset "${Esc}[m")
     set(BoldMagenta "${Esc}[1;35m")
     set(Magenta "${Esc}[35m")
-endif ()
+endif()
 
 # Print CMAKE_BINARY_DIR
 message("CMAKE_BINARY_DIR: ${CMAKE_BINARY_DIR}")
@@ -21,37 +24,40 @@ message("CATKIN_GLOBAL_INCLUDE_DESTINATION: ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
 # Print CATKIN_GLOBAL_LIB_DESTINATION
 message("CATKIN_GLOBAL_LIB_DESTINATION: ${CATKIN_GLOBAL_LIB_DESTINATION}")
 
-# Graph MSF
-include(ExternalProject)
-file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
+# Ensure CATKIN_DEVEL_PREFIX is set, otherwise use a fallback
+if(NOT CATKIN_DEVEL_PREFIX)
+    set(CATKIN_DEVEL_PREFIX "${CMAKE_BINARY_DIR}/devel")
+endif()
 
-ExternalProject_Add(graph_msf
-  SOURCE_DIR ${CMAKE_SOURCE_DIR}/../../graph_msf
-  PREFIX      "${CMAKE_SOURCE_DIR}"
-  TMP_DIR     "${CMAKE_BINARY_DIR}/graph_msf/tmp"
-  BINARY_DIR  "${CMAKE_BINARY_DIR}/graph_msf/build"
-  INSTALL_DIR "${CATKIN_DEVEL_PREFIX}"
-  CMAKE_CACHE_ARGS "-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true"
-  CMAKE_ARGS
-    -DCMAKE_BUILD_TYPE=Release
-    -DCMAKE_INSTALL_PREFIX=${CATKIN_DEVEL_PREFIX}
-  BUILD_ALWAYS 1
+# Add the non-Catkin package ----------------------------------------------
+file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
+add_subdirectory(${CMAKE_SOURCE_DIR}/../../graph_msf
+    ${CATKIN_DEVEL_PREFIX}/lib
 )
 
-# Dependencies ---------------------------------------------------------
-add_dependencies(graph_msf ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})
+# Move the include directory to the correct location
+add_custom_target(copy_graph_msf ALL
+    # Include
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CATKIN_DEVEL_PREFIX}/include
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${CMAKE_SOURCE_DIR}/../../graph_msf/include/graph_msf"
+            "${CATKIN_DEVEL_PREFIX}/include/graph_msf"
+)
 
 #############
 ## INSTALL ##
 #############
 
-install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/
-        DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
-        )
+# Install the include directory
+install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/.private/graph_msf_catkin/include
+        DESTINATION ${CATKIN_DEVEL_PREFIX}/include/graph_msf
+)
 
-install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/lib/
-        DESTINATION ${CATKIN_GLOBAL_LIB_DESTINATION}
-        )
+# Install the library
+install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/.private/graph_msf_catkin/lib
+        DESTINATION ${CATKIN_DEVEL_PREFIX}/lib
+        FILES_MATCHING PATTERN "*.so"
+)
 
 # Final catkin package --------------------------------------------------
 catkin_package(
@@ -64,3 +70,4 @@ catkin_package(
         ${${PROJECT_NAME}_CATKIN_RUN_DEPENDS}
         ${CATKIN_PACKAGE_DEPENDENCIES}
 )
+

--- a/ros/graph_msf_catkin/CMakeLists.txt
+++ b/ros/graph_msf_catkin/CMakeLists.txt
@@ -44,6 +44,10 @@ add_custom_target(copy_graph_msf ALL
             "${CATKIN_DEVEL_PREFIX}/include/graph_msf"
 )
 
+# GTSAM --> Also expose
+find_package(GTSAM REQUIRED)
+find_package(GTSAM_UNSTABLE REQUIRED)
+
 #############
 ## INSTALL ##
 #############
@@ -66,6 +70,9 @@ catkin_package(
     LIBRARIES
         ${CATKIN_DEVEL_PREFIX}/lib/libgraph_msf.so
         ${CS_PROJECT_LIBRARIES}
+        gtsam
+        gtsam_unstable
+        metis-gtsam
     CATKIN_DEPENDS
         ${${PROJECT_NAME}_CATKIN_RUN_DEPENDS}
         ${CATKIN_PACKAGE_DEPENDENCIES}

--- a/ros/graph_msf_catkin/CMakeLists.txt
+++ b/ros/graph_msf_catkin/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required(VERSION 3.10)
+project(graph_msf_catkin)
+
+find_package(catkin REQUIRED)
+
+# Color
+if (NOT WIN32)
+    string(ASCII 27 Esc)
+    set(ColourReset "${Esc}[m")
+    set(BoldMagenta "${Esc}[1;35m")
+    set(Magenta "${Esc}[35m")
+endif ()
+
+# Print CMAKE_BINARY_DIR
+message("CMAKE_BINARY_DIR: ${CMAKE_BINARY_DIR}")
+message("CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
+# Print CMAKE_DEVEL_PREFIX
+message("CATKIN_DEVEL_PREFIX: ${CATKIN_DEVEL_PREFIX}")
+# Print CATKIN_GLOBAL_INCLUDE_DESTINATION
+message("CATKIN_GLOBAL_INCLUDE_DESTINATION: ${CATKIN_GLOBAL_INCLUDE_DESTINATION}")
+# Print CATKIN_GLOBAL_LIB_DESTINATION
+message("CATKIN_GLOBAL_LIB_DESTINATION: ${CATKIN_GLOBAL_LIB_DESTINATION}")
+
+# Graph MSF
+include(ExternalProject)
+file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
+
+ExternalProject_Add(graph_msf
+  SOURCE_DIR ${CMAKE_SOURCE_DIR}/../../graph_msf
+  PREFIX      "${CMAKE_SOURCE_DIR}"
+  TMP_DIR     "${CMAKE_BINARY_DIR}/graph_msf/tmp"
+  BINARY_DIR  "${CMAKE_BINARY_DIR}/graph_msf/build"
+  INSTALL_DIR "${CATKIN_DEVEL_PREFIX}"
+  CMAKE_CACHE_ARGS "-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true"
+  CMAKE_ARGS
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_INSTALL_PREFIX=${CATKIN_DEVEL_PREFIX}
+  BUILD_ALWAYS 1
+)
+
+# Dependencies ---------------------------------------------------------
+add_dependencies(graph_msf ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})
+
+#############
+## INSTALL ##
+#############
+
+install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/
+        DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+        )
+
+install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/lib/
+        DESTINATION ${CATKIN_GLOBAL_LIB_DESTINATION}
+        )
+
+# Final catkin package --------------------------------------------------
+catkin_package(
+    INCLUDE_DIRS
+        ${CATKIN_DEVEL_PREFIX}/include
+    LIBRARIES
+        ${CATKIN_DEVEL_PREFIX}/lib/libgraph_msf.so
+        ${CS_PROJECT_LIBRARIES}
+    CATKIN_DEPENDS
+        ${${PROJECT_NAME}_CATKIN_RUN_DEPENDS}
+        ${CATKIN_PACKAGE_DEPENDENCIES}
+)

--- a/ros/graph_msf_catkin/package.xml
+++ b/ros/graph_msf_catkin/package.xml
@@ -1,0 +1,12 @@
+<package format="2">
+  <name>graph_msf_catkin</name>
+  <version>0.0.1</version>
+
+  <description>Catkin wrapper for native CMake project graph_msf</description>
+  
+  <maintainer email="nubertj@ethz.ch">Julian Nubert</maintainer>
+  <license>BSD</license>
+  <author email="nubertj@ethz.ch">Julian Nubert</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+</package>

--- a/ros/graph_msf_ros/CMakeLists.txt
+++ b/ros/graph_msf_ros/CMakeLists.txt
@@ -28,7 +28,7 @@ endif ()
 # Catkin
 set(CATKIN_PACKAGE_DEPENDENCIES
         roscpp
-        graph_msf
+        graph_msf_catkin
         kdl_parser
         nav_msgs
         geometry_msgs
@@ -78,8 +78,9 @@ add_library(${PROJECT_NAME}
         src/lib/GraphMsfRos.cpp
         src/lib/readParams.cpp
         src/lib/conversions.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
+# Link against graph_msf and its dependencies
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 
 # Add clang tooling

--- a/ros/graph_msf_ros/package.xml
+++ b/ros/graph_msf_ros/package.xml
@@ -15,7 +15,7 @@
     <buildtool_depend>catkin</buildtool_depend>
     <build_depend>roscpp</build_depend>
     <build_depend>rospy</build_depend>
-    <build_depend>graph_msf</build_depend>
+    <build_depend>graph_msf_catkin</build_depend>
     <build_depend>kdl_parser</build_depend>
     <build_depend>nav_msgs</build_depend>
     <build_depend>geometry_msgs</build_depend>
@@ -26,7 +26,7 @@
     <exec_depend>roscpp</exec_depend>
     <exec_depend>rospy</exec_depend>
     <exec_depend>python3</exec_depend>
-    <exec_depend>graph_msf</exec_depend>
+    <exec_depend>graph_msf_catkin</exec_depend>
     <exec_depend>kdl_parser</exec_depend>
     <exec_depend>nav_msgs</exec_depend>
     <exec_depend>geometry_msgs</exec_depend>


### PR DESCRIPTION
I think with the new requirements of being buildsystem independent we have to move away from gtsam_catkin.

Instead I propose:

1. System install (potentially local installation) of `gtsam`
2. `graph_msf` as pure cmake package
3. slim `graph_msf_catkin` to make graph_msf available directly to catkin packages and to still comfortably develop / debug
4. Downstream packages such as `graph_msf_ros` or `smb_estimator_graph` then simply use `graph_msf_catkin`.

For ros2/colcon, which is much closer to cmake, we can see what is the best solution and whether we can avoid having a `graph_msf_ament`. I think it should also work without.

First running prototype attached to this PR. Happy about any testers on existing data.