### PR TITLE
SMB bugfix: fixed ordering of param reading and flag setting for static tfs

### DIFF
--- a/ros2/examples/smb_estimator_graph_ros2/src/lib/SmbEstimator.cpp
+++ b/ros2/examples/smb_estimator_graph_ros2/src/lib/SmbEstimator.cpp
@@ -22,17 +22,6 @@ namespace smb_se {
 SmbEstimator::SmbEstimator(std::shared_ptr<rclcpp::Node>& node) : graph_msf::GraphMsfRos2(node) {
   REGULAR_COUT << GREEN_START << " SmbEstimator-Constructor called." << COLOR_END << std::endl;
 
-  staticTransformsPtr_ = std::make_shared<SmbStaticTransforms>(node_);
-
-  // Set the odometry flags in SmbStaticTransforms
-  auto smbStaticTransforms = std::dynamic_pointer_cast<SmbStaticTransforms>(staticTransformsPtr_);
-  if (smbStaticTransforms) {
-    smbStaticTransforms->setUseLioOdometryFlag(useLioOdometryFlag_);
-    smbStaticTransforms->setUseVioOdometryFlag(useVioOdometryFlag_);
-    smbStaticTransforms->setUseWheelOdometryBetweenFlag(useWheelOdometryBetweenFlag_);
-    smbStaticTransforms->setUseWheelLinearVelocitiesFlag(useWheelLinearVelocitiesFlag_);
-  }
-
   // Call setup after declaring parameters
   SmbEstimator::setup();
 }
@@ -71,6 +60,9 @@ void SmbEstimator::setup() {
 
   // Wheel Radius (double)
   node_->declare_parameter("sensor_params.wheelRadius", 0.0);
+
+  // Create SmbStaticTransforms
+  staticTransformsPtr_ = std::make_shared<SmbStaticTransforms>(node_);
 
   SmbEstimator::readParams();
 

--- a/ros2/examples/smb_estimator_graph_ros2/src/lib/readParams.cpp
+++ b/ros2/examples/smb_estimator_graph_ros2/src/lib/readParams.cpp
@@ -25,9 +25,13 @@ void SmbEstimator::readParams() {
 
   // Flags
   useLioOdometryFlag_ = graph_msf::tryGetParam<bool>(node_, "sensor_params.useLioOdometry");
+  dynamic_cast<SmbStaticTransforms*>(staticTransformsPtr_.get())->setUseLioOdometryFlag(useLioOdometryFlag_);
   useWheelOdometryBetweenFlag_ = graph_msf::tryGetParam<bool>(node_, "sensor_params.useWheelOdometryBetween");
+  dynamic_cast<SmbStaticTransforms*>(staticTransformsPtr_.get())->setUseWheelOdometryBetweenFlag(useWheelOdometryBetweenFlag_);
   useWheelLinearVelocitiesFlag_ = graph_msf::tryGetParam<bool>(node_, "sensor_params.useWheelLinearVelocities");
+  dynamic_cast<SmbStaticTransforms*>(staticTransformsPtr_.get())->setUseWheelLinearVelocitiesFlag(useWheelLinearVelocitiesFlag_);
   useVioOdometryFlag_ = graph_msf::tryGetParam<bool>(node_, "sensor_params.useVioOdometry");
+  dynamic_cast<SmbStaticTransforms*>(staticTransformsPtr_.get())->setUseVioOdometryFlag(useVioOdometryFlag_);
 
   // Sensor Params
   lioOdometryRate_ = graph_msf::tryGetParam<int>(node_, "sensor_params.lioOdometryRate");


### PR DESCRIPTION
The flags were being set before the parameters were read. The code logic has been modified to correct this, and tested in IMU-only, IMU + LIO from Open3dSLAM, and IMU + wheel velocities