### PR TITLE
gtsam include directory needs to be exposed (if no gtsam_catkin)

### DIFF
--- a/ros/graph_msf_catkin/CMakeLists.txt
+++ b/ros/graph_msf_catkin/CMakeLists.txt
@@ -67,6 +67,7 @@ install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/.private/graph_msf_catkin/lib
 catkin_package(
     INCLUDE_DIRS
         ${CATKIN_DEVEL_PREFIX}/include
+        ${GTSAM_INCLUDE_DIR}
     LIBRARIES
         ${CATKIN_DEVEL_PREFIX}/lib/libgraph_msf.so
         ${CS_PROJECT_LIBRARIES}


### PR DESCRIPTION
having moved away from gtsam_catkin as a dependency, graph_msf_ros was failing to build (with custom GTSAM install directory) because graph_msf_catkin was not exposing the GTSAM include directory, fixed by this PR

(build bug was found in clean rsl_seam docker setup where GTSAM is installed under `/opt/gtsam`)