### PR TITLE
GraphMSF: require IMU topic + lock TF + silence REGULAR_COUT

### DIFF
--- a/graph_msf/include/graph_msf/config/StaticTransforms.h
+++ b/graph_msf/include/graph_msf/config/StaticTransforms.h
@@ -10,6 +10,7 @@ Please see the LICENSE file that has been included as part of this package.
 
 // Eigen
 #include <Eigen/Eigen>
+#include <shared_mutex>
 
 // Workspace
 #include "graph_msf/core/TransformsDictionary.h"
@@ -36,6 +37,7 @@ class StaticTransforms : public TransformsDictionary<Eigen::Isometry3d> {
   const std::string& getOdomFrame() { return odomFrame_; }
   const std::string& getBaseLinkFrame() { return baseLinkFrame_; }
   const std::string& getInitializationFrame() { return initializationFrame_; }
+  std::shared_mutex& mutex() const { return transformsMutex_; }
 
   // Functionality ------------------------------------------------------------
   virtual bool findTransformations() = 0;
@@ -47,6 +49,9 @@ class StaticTransforms : public TransformsDictionary<Eigen::Isometry3d> {
   std::string imuFrame_;
   std::string baseLinkFrame_;
   std::string initializationFrame_;
+
+ private:
+  mutable std::shared_mutex transformsMutex_;
 };
 
 }  // namespace graph_msf

--- a/graph_msf/include/graph_msf/core/DynamicFactorGraphStateKey.h
+++ b/graph_msf/include/graph_msf/core/DynamicFactorGraphStateKey.h
@@ -13,6 +13,9 @@ Please see the LICENSE file that has been included as part of this package.
 #define FACTOR_GRAPH_STATE_KEY_H
 
 // Output
+#ifdef REGULAR_COUT
+#undef REGULAR_COUT
+#endif
 #define REGULAR_COUT std::cout << YELLOW_START << "GMSF-FactorGraphStateKey" << COLOR_END
 
 namespace graph_msf {

--- a/graph_msf/include/graph_msf/core/DynamicTransformDictionary.h
+++ b/graph_msf/include/graph_msf/core/DynamicTransformDictionary.h
@@ -9,6 +9,9 @@ Please see the LICENSE file that has been included as part of this package.
 #define TRANSFORMS_EXPRESSION_KEYS_H
 
 // Output
+#ifdef REGULAR_COUT
+#undef REGULAR_COUT
+#endif
 #define REGULAR_COUT std::cout << YELLOW_START << "GMSF-TransformExpressionKeys" << COLOR_END
 
 // Workspace

--- a/graph_msf/include/graph_msf/core/FileLogger.h
+++ b/graph_msf/include/graph_msf/core/FileLogger.h
@@ -58,7 +58,7 @@ class FileLogger {
   // Pose3
   static void writePose3ToCsvFile(std::map<std::string, std::ofstream>& fileStreams, const gtsam::Pose3& pose,
                                   const std::string& transformIdentifier, const double timeStamp, const bool saveCovarianceFlag,
-                                  boost::optional<const Eigen::Matrix<double, 6, 6>&> optionalPoseCovarianceInWorldRos = boost::none);
+                                  const Eigen::Matrix<double, 6, 6>* optionalPoseCovarianceInWorldRos = nullptr);
   // Latitude, Longitude, Altitude
   static void writeLatLonAltToCsvFile(std::map<std::string, std::ofstream>& fileStreams, const gtsam::Point3& point,
                                       const std::string& transformIdentifier, const double timeStamp);

--- a/graph_msf/include/graph_msf/core/GraphManager.h
+++ b/graph_msf/include/graph_msf/core/GraphManager.h
@@ -18,6 +18,8 @@ Please see the LICENSE file that has been included as part of this package.
 #include <gtsam/slam/expressions.h>
 
 // Package
+#include <gtsam/linear/LossFunctions.h>
+#include <gtsam/nonlinear/ExpressionFactor.h>
 #include "graph_msf/config/GraphConfig.h"
 #include "graph_msf/core/DynamicDictionaryContainer.h"
 #include "graph_msf/core/FileLogger.h"
@@ -30,8 +32,6 @@ Please see the LICENSE file that has been included as part of this package.
 #include "graph_msf/measurements/UnaryMeasurement.h"
 #include "graph_msf/measurements/UnaryMeasurementAbsolute.h"
 #include "graph_msf/measurements/UnaryMeasurementXD.h"
-#include <gtsam/nonlinear/ExpressionFactor.h>
-#include <gtsam/linear/LossFunctions.h>
 
 // General Unary Factor Interface
 #include "graph_msf/factors/gmsf_expression/GmsfUnaryExpression.h"
@@ -187,7 +187,7 @@ class GraphManager {
   FileLogger fileLogger_;
 
   // Objects
-  boost::shared_ptr<gtsam::PreintegratedCombinedMeasurements::Params> imuParamsPtr_;
+  std::shared_ptr<gtsam::PreintegratedCombinedMeasurements::Params> imuParamsPtr_;
   std::shared_ptr<gtsam::imuBias::ConstantBias> imuBiasPriorPtr_;
   graph_msf::GraphState optimizedGraphState_;
   /// Propagated state (at IMU frequency)

--- a/graph_msf/include/graph_msf/core/GraphManager.inl
+++ b/graph_msf/include/graph_msf/core/GraphManager.inl
@@ -87,7 +87,7 @@ void GraphManager::addUnaryGmsfExpressionFactor(const std::shared_ptr<GMSF_EXPRE
   // Robust Error Function?
   const RobustNormEnum robustNormEnum(gmsfUnaryExpressionPtr->getGmsfBaseUnaryMeasurementPtr()->robustNormEnum());
   const double robustNormConstant = gmsfUnaryExpressionPtr->getGmsfBaseUnaryMeasurementPtr()->robustNormConstant();
-  boost::shared_ptr<gtsam::noiseModel::Robust> robustErrorFunction;
+  gtsam::noiseModel::Robust::shared_ptr robustErrorFunction;
   // Pick Robust Error Function
   switch (robustNormEnum) {
     case RobustNormEnum::Huber:

--- a/graph_msf/include/graph_msf/core/TransformsDictionary.h
+++ b/graph_msf/include/graph_msf/core/TransformsDictionary.h
@@ -99,9 +99,6 @@ class TransformsDictionary {
     // Check whether transformation pair is already there
     if (!isFramePairInDictionary(frame1, frame2)) {
       ++numStoredTransforms_;
-    } else {
-      std::cout << YELLOW_START << "GMsf-TransformsDict" << COLOR_END << " Transformation pair " << frame1 << " and " << frame2
-                << " already exists." << std::endl;
     }
     // Set transformation
     lv_T_frame1_frame2(frame1, frame2) = T_frame1_frame2;

--- a/graph_msf/include/graph_msf/core/optimizer/OptimizerBase.h
+++ b/graph_msf/include/graph_msf/core/optimizer/OptimizerBase.h
@@ -9,10 +9,10 @@ Please see the LICENSE file that has been included as part of this package.
 #define OPTIMIZER_BASE_HPP
 
 // GTSAM
+#include <gtsam/geometry/Pose3.h>
 #include <gtsam/navigation/ImuBias.h>
 #include <gtsam/nonlinear/ISAM2Result.h>
 #include <gtsam_unstable/nonlinear/FixedLagSmoother.h>
-#include <gtsam/geometry/Pose3.h>
 
 // Workspace
 #include "graph_msf/config/GraphConfig.h"
@@ -50,14 +50,10 @@ class OptimizerBase {
   virtual gtsam::Matrix calculateMarginalCovarianceMatrixAtKey(const gtsam::Key& key) = 0;
 
   // Add latest IMU bias before optimization
-  virtual void addLatestImuBiasBelief(const gtsam::imuBias::ConstantBias& imuBias) {
-    latestImuBias_ = imuBias;
-  }
+  virtual void addLatestImuBiasBelief(const gtsam::imuBias::ConstantBias& imuBias) { latestImuBias_ = imuBias; }
 
   // Add latest pose before optimization
-  virtual void addLatestPoseBelief(const gtsam::Pose3& pose) {
-    latestPose_ = pose;
-  }
+  virtual void addLatestPoseBelief(const gtsam::Pose3& pose) { latestPose_ = pose; }
 
  protected:
   // Config

--- a/graph_msf/include/graph_msf/core/optimizer/OptimizerIsam2FixedLag.hpp
+++ b/graph_msf/include/graph_msf/core/optimizer/OptimizerIsam2FixedLag.hpp
@@ -38,8 +38,22 @@ class OptimizerIsam2FixedLag : public OptimizerIsam2 {
   ~OptimizerIsam2FixedLag() = default;
 
   bool update() override {
-    fixedLagSmootherPtr_->update();
-    return true;
+    // Keep update() exception-safe by rolling back to the previous smoother state on failure.
+    gtsam::IncrementalFixedLagSmoother fixedLagSmootherCopy = *fixedLagSmootherPtr_;
+    try {
+      fixedLagSmootherPtr_->update();
+      return true;
+    } catch (const gtsam::IndeterminantLinearSystemException& e) {
+      *fixedLagSmootherPtr_ = fixedLagSmootherCopy;
+      std::cerr << YELLOW_START << "GMsf-ISAM2" << RED_START
+                << " IndeterminantLinearSystem exception during additional update(): '" << e.what() << "'" << COLOR_END << std::endl;
+      return false;
+    } catch (const std::exception& e) {
+      *fixedLagSmootherPtr_ = fixedLagSmootherCopy;
+      std::cerr << YELLOW_START << "GMsf-ISAM2" << RED_START << " Exception during additional update(): '" << e.what() << "'"
+                << COLOR_END << std::endl;
+      return false;
+    }
   }
 
   bool update(const gtsam::NonlinearFactorGraph& newGraphFactors, const gtsam::Values& newGraphValues,

--- a/graph_msf/include/graph_msf/core/optimizer/OptimizerIsam2FixedLag.hpp
+++ b/graph_msf/include/graph_msf/core/optimizer/OptimizerIsam2FixedLag.hpp
@@ -46,8 +46,7 @@ class OptimizerIsam2FixedLag : public OptimizerIsam2 {
               const std::map<gtsam::Key, double>& newGraphKeysTimeStampMap, const int depth = 0) {
     // Limit recursion depth to prevent infinite loops
     if (depth > 5) {
-      std::cout << YELLOW_START << "GMsf-ISAM2" << RED_START 
-                << " Maximum recursion depth reached (" << depth << "). Aborting optimization." 
+      std::cout << YELLOW_START << "GMsf-ISAM2" << RED_START << " Maximum recursion depth reached (" << depth << "). Aborting optimization."
                 << COLOR_END << std::endl;
       return false;
     }

--- a/graph_msf/include/graph_msf/factors/gmsf_expression/GmsfUnaryExpressionAbsolut.h
+++ b/graph_msf/include/graph_msf/factors/gmsf_expression/GmsfUnaryExpressionAbsolut.h
@@ -127,7 +127,7 @@ class GmsfUnaryExpressionAbsolut : public GmsfUnaryExpression<GTSAM_MEASUREMENT_
       // Container for belief of old keyframe
       gtsam::Pose3 T_W_fixedFrameOld;
       // Noise model container
-      boost::shared_ptr<gtsam::noiseModel::Base> noiseModelPtr;
+      gtsam::SharedNoiseModel noiseModelPtr;
       // Case 1: Has been optimized before
       if (oldKeyPtr->getNumberStepsOptimized() > 0) {
         T_W_fixedFrameOld = oldKeyPtr->getTransformationAfterOptimization();
@@ -219,7 +219,7 @@ class GmsfUnaryExpressionAbsolut : public GmsfUnaryExpression<GTSAM_MEASUREMENT_
 
         // a): Random Walk between the two
         if (gmsfUnaryAbsoluteMeasurementPtr_->modelAsRandomWalkFlag()) {
-          boost::shared_ptr<gtsam::noiseModel::Diagonal> noiseModelPtr =
+          gtsam::SharedDiagonal noiseModelPtr =
               gtsam::noiseModel::Diagonal::Sigmas(gmsfUnaryAbsoluteMeasurementPtr_->se3AlignmentRandomWalk());
           this->newOnlineAndOfflinePoseBetweenFactors_.emplace_back(oldGtsamKey, graphKey.key(), T_fixedFrameOld_fixedFrame, noiseModelPtr);
 
@@ -237,7 +237,7 @@ class GmsfUnaryExpressionAbsolut : public GmsfUnaryExpression<GTSAM_MEASUREMENT_
         }
         // b): Deterministic displacement modelled as equality constraint
         else {
-          boost::shared_ptr<gtsam::noiseModel::Constrained> noiseModelPtr =
+          gtsam::SharedConstrained noiseModelPtr =
               gtsam::noiseModel::Constrained::MixedSigmas(gmsfUnaryAbsoluteMeasurementPtr_->se3AlignmentRandomWalk());
           this->newOnlineAndOfflinePoseBetweenFactors_.emplace_back(oldGtsamKey, graphKey.key(), T_fixedFrameOld_fixedFrame, noiseModelPtr);
 

--- a/graph_msf/include/graph_msf/factors/gmsf_expression/GmsfUnaryExpressionLocalVelocity3.h
+++ b/graph_msf/include/graph_msf/factors/gmsf_expression/GmsfUnaryExpressionLocalVelocity3.h
@@ -33,7 +33,8 @@ class GmsfUnaryExpressionLocalVelocity3 final : public GmsfUnaryExpressionLocal<
     // Check whether we can find an IMU measurement corresponding to the velocity measurement
     double imuTimestamp;
     graph_msf::ImuMeasurement imuMeasurement = graph_msf::ImuMeasurement();
-    if (!imuBufferPtr->getClosestImuMeasurement(imuTimestamp, imuMeasurement, 0.1, velocityUnaryMeasurementPtr->timeK())) { // previously 0.02
+    if (!imuBufferPtr->getClosestImuMeasurement(imuTimestamp, imuMeasurement, 0.1,
+                                                velocityUnaryMeasurementPtr->timeK())) {  // previously 0.02
       REGULAR_COUT << RED_START << " No IMU Measurement (in time interval) found, assuming 0 angular velocity for the factor." << COLOR_END
                    << std::endl;
     }

--- a/graph_msf/include/graph_msf/factors/non_expression/unaryPitchFactor.h
+++ b/graph_msf/include/graph_msf/factors/non_expression/unaryPitchFactor.h
@@ -9,8 +9,7 @@ Please see the LICENSE file that has been included as part of this package.
 #define GRAPH_MSF_PITCH_FACTOR_H
 
 // CPP
-#include <boost/none.hpp>
-#include <boost/shared_ptr.hpp>
+#include <cmath>
 
 // GTSAM
 #include <gtsam/base/OptionalJacobian.h>
@@ -33,7 +32,8 @@ class PitchFactor : public gtsam::NoiseModelFactor1<gtsam::Pose3> {
    * @param measured pitch reading
    * @param model of the additive Gaussian noise that is assumed
    */
-  PitchFactor(gtsam::Key j, double pitch, const gtsam::SharedNoiseModel& model) : gtsam::NoiseModelFactor1<gtsam::Pose3>(model, j), pitch_(pitch) {}
+  PitchFactor(gtsam::Key j, double pitch, const gtsam::SharedNoiseModel& model)
+      : gtsam::NoiseModelFactor1<gtsam::Pose3>(model, j), pitch_(pitch) {}
 
   // Destructor
   virtual ~PitchFactor() {}
@@ -42,25 +42,29 @@ class PitchFactor : public gtsam::NoiseModelFactor1<gtsam::Pose3> {
    * Evaluate error function
    * @brief vector of errors
    */
-  gtsam::Vector evaluateError(const gtsam::Pose3& robotPose, boost::optional<gtsam::Matrix&> H_Ptr = boost::none) const {
+  gtsam::Vector evaluateError(const gtsam::Pose3& robotPose, gtsam::OptionalMatrixType H = OptionalNone) const override {
     // If close to singularity, do not add measurement
     if (std::abs(robotPose.rotation().pitch()) >= M_PI / 2.0 - 0.1) {
-      if (H_Ptr) {
-        (*H_Ptr) = gtsam::Matrix::Zero(1, 6);
+      if (H) {
+        (*H) = gtsam::Matrix::Zero(1, 6);
       }
       return gtsam::Vector1::Zero();
     }
 
+    gtsam::Matrix13 H_rot;
+    const double pitch_meas = H ? robotPose.rotation().pitch(gtsam::OptionalJacobian<1, 3>(H_rot)) : robotPose.rotation().pitch();
+
     // calculate error
-    double pitchError = robotPose.rotation().pitch(H_Ptr) - pitch_;
+    double pitchError = pitch_meas - pitch_;
 
     // Smaller half circle
     while (pitchError < -M_PI) pitchError += 2 * M_PI;
     while (pitchError > M_PI) pitchError -= 2 * M_PI;
 
     // Jacobian
-    if (H_Ptr) {
-      (*H_Ptr) = (gtsam::Matrix(1, 6) << *H_Ptr, 0.0, 0.0, 0.0).finished();  // [rad] [m]
+    if (H) {
+      (*H) = gtsam::Matrix::Zero(1, 6);
+      (*H).block<1, 3>(0, 0) = H_rot;
     }
 
     return gtsam::Vector1(pitchError);

--- a/graph_msf/include/graph_msf/factors/non_expression/unaryRollFactor.h
+++ b/graph_msf/include/graph_msf/factors/non_expression/unaryRollFactor.h
@@ -9,8 +9,7 @@ Please see the LICENSE file that has been included as part of this package.
 #define GRAPH_MSF_ROLL_FACTOR_H
 
 // CPP
-#include <boost/none.hpp>
-#include <boost/shared_ptr.hpp>
+#include <cmath>
 
 // GTSAM
 #include <gtsam/base/OptionalJacobian.h>
@@ -33,7 +32,8 @@ class RollFactor : public gtsam::NoiseModelFactor1<gtsam::Pose3> {
    * @param measured roll reading
    * @param model of the additive Gaussian noise that is assumed
    */
-  RollFactor(gtsam::Key j, double roll, const gtsam::SharedNoiseModel& model) : gtsam::NoiseModelFactor1<gtsam::Pose3>(model, j), roll_(roll) {}
+  RollFactor(gtsam::Key j, double roll, const gtsam::SharedNoiseModel& model)
+      : gtsam::NoiseModelFactor1<gtsam::Pose3>(model, j), roll_(roll) {}
 
   // Destructor
   virtual ~RollFactor() {}
@@ -42,25 +42,29 @@ class RollFactor : public gtsam::NoiseModelFactor1<gtsam::Pose3> {
    * Evaluate error function
    * @brief vector of errors
    */
-  gtsam::Vector evaluateError(const gtsam::Pose3& robotPose, boost::optional<gtsam::Matrix&> H_Ptr = boost::none) const {
-        // If close to singularity, do not add measurement
+  gtsam::Vector evaluateError(const gtsam::Pose3& robotPose, gtsam::OptionalMatrixType H = OptionalNone) const override {
+    // If close to singularity, do not add measurement
     if (std::abs(robotPose.rotation().roll()) >= M_PI / 2.0 - 0.1) {
-      if (H_Ptr) {
-        (*H_Ptr) = gtsam::Matrix::Zero(1, 6);
+      if (H) {
+        (*H) = gtsam::Matrix::Zero(1, 6);
       }
       return gtsam::Vector1::Zero();
     }
 
+    gtsam::Matrix13 H_rot;
+    const double roll_meas = H ? robotPose.rotation().roll(gtsam::OptionalJacobian<1, 3>(H_rot)) : robotPose.rotation().roll();
+
     // calculate error
-    double rollError = robotPose.rotation().roll(H_Ptr) - roll_;
+    double rollError = roll_meas - roll_;
 
     // Smaller half circle
     while (rollError < -M_PI) rollError += 2 * M_PI;
     while (rollError > M_PI) rollError -= 2 * M_PI;
 
     // Jacobian
-    if (H_Ptr) {
-      (*H_Ptr) = (gtsam::Matrix(1, 6) << *H_Ptr, 0.0, 0.0, 0.0).finished();  // [rad] [m]
+    if (H) {
+      (*H) = gtsam::Matrix::Zero(1, 6);
+      (*H).block<1, 3>(0, 0) = H_rot;
     }
 
     return gtsam::Vector1(rollError);

--- a/graph_msf/include/graph_msf/factors/non_expression/unaryYawFactor.h
+++ b/graph_msf/include/graph_msf/factors/non_expression/unaryYawFactor.h
@@ -9,8 +9,7 @@ Please see the LICENSE file that has been included as part of this package.
 #define GRAPH_MSF_HEADING_FACTOR_H
 
 // CPP
-#include <boost/none.hpp>
-#include <boost/shared_ptr.hpp>
+#include <cmath>
 
 // GTSAM
 #include <gtsam/base/OptionalJacobian.h>
@@ -42,25 +41,29 @@ class YawFactor : public gtsam::NoiseModelFactor1<gtsam::Pose3> {
    * Evaluate error function
    * @brief vector of errors
    */
-  gtsam::Vector evaluateError(const gtsam::Pose3& robotPose, boost::optional<gtsam::Matrix&> H_Ptr = boost::none) const {
+  gtsam::Vector evaluateError(const gtsam::Pose3& robotPose, gtsam::OptionalMatrixType H = OptionalNone) const override {
     // If close to singularity, do not add measurement
     if (std::abs(robotPose.rotation().pitch()) >= M_PI / 2.0 - 0.1 || std::abs(robotPose.rotation().roll()) >= M_PI / 2.0 - 0.1) {
-      if (H_Ptr) {
-        (*H_Ptr) = gtsam::Matrix::Zero(1, 6);
+      if (H) {
+        (*H) = gtsam::Matrix::Zero(1, 6);
       }
       return gtsam::Vector1::Zero();
     }
 
+    gtsam::Matrix13 H_rot;
+    const double yaw_meas = H ? robotPose.rotation().yaw(gtsam::OptionalJacobian<1, 3>(H_rot)) : robotPose.rotation().yaw();
+
     // calculate error
-    double yawError = robotPose.rotation().yaw(H_Ptr) - yaw_;
+    double yawError = yaw_meas - yaw_;
 
     // Smaller half circle
     while (yawError < -M_PI) yawError += 2 * M_PI;
     while (yawError > M_PI) yawError -= 2 * M_PI;
 
     // Jacobian
-    if (H_Ptr) {
-      (*H_Ptr) = (gtsam::Matrix(1, 6) << *H_Ptr, 0.0, 0.0, 0.0).finished();  // [rad] [m]
+    if (H) {
+      (*H) = gtsam::Matrix::Zero(1, 6);
+      (*H).block<1, 3>(0, 0) = H_rot;
     }
 
     return gtsam::Vector1(yawError);

--- a/graph_msf/include/graph_msf/geometry/Trajectory.h
+++ b/graph_msf/include/graph_msf/geometry/Trajectory.h
@@ -1,9 +1,9 @@
 #ifndef GRAPH_MSF_TRAJECTORY_H
 #define GRAPH_MSF_TRAJECTORY_H
 
-#include <vector>
-#include <algorithm>
 #include <Eigen/Core>
+#include <algorithm>
+#include <vector>
 #include "graph_msf/geometry/Pose.h"
 
 namespace graph_msf {
@@ -26,28 +26,22 @@ class Trajectory {
     _poses.push_back(newPose);
   }
 
-  void addPose(const Pose& pose) {
-    _poses.push_back(pose);
-  }
+  void addPose(const Pose& pose) { _poses.push_back(pose); }
 
-  void addPoseWithFilter(const Eigen::Vector3d& position,
-                         double                time,
-                         const Eigen::Vector3d& covariance,
-                         double                timeConstant = 0.5)
-  {
+  void addPoseWithFilter(const Eigen::Vector3d& position, double time, const Eigen::Vector3d& covariance, double timeConstant = 0.5) {
     if (_poses.empty()) {
-      _filteredPos   = position;
-      _filteredCov   = covariance;
-      _poses.emplace_back(position, Eigen::Vector4d(0,0,0,1), time);
-      _lastTime      = time;
+      _filteredPos = position;
+      _filteredCov = covariance;
+      _poses.emplace_back(position, Eigen::Vector4d(0, 0, 0, 1), time);
+      _lastTime = time;
       return;
     }
 
-    double dt        = std::max(1e-6, time - _lastTime);  
-    double alpha_t   = 1.0 - std::exp(-dt / timeConstant);
+    double dt = std::max(1e-6, time - _lastTime);
+    double alpha_t = 1.0 - std::exp(-dt / timeConstant);
 
-    double w_new     = 1.0 / (covariance.array().max(1e-6)).mean();
-    double w_old     = 1.0 / (_filteredCov.array().max(1e-6)).mean();
+    double w_new = 1.0 / (covariance.array().max(1e-6)).mean();
+    double w_old = 1.0 / (_filteredCov.array().max(1e-6)).mean();
     double alpha_cov = w_new / (w_new + w_old);
 
     double alpha = alpha_t * alpha_cov;
@@ -60,18 +54,14 @@ class Trajectory {
     _filteredPos = (1.0 - alpha) * _filteredPos + alpha * position;
     _filteredCov = (1.0 - alpha) * _filteredCov + alpha * covariance;
 
-    _poses.emplace_back(_filteredPos, Eigen::Vector4d(0,0,0,1), time);
+    _poses.emplace_back(_filteredPos, Eigen::Vector4d(0, 0, 0, 1), time);
     _lastTime = time;
   }
 
-  void clear() {
-    _poses.clear();
-  }
+  void clear() { _poses.clear(); }
 
   // Optionally release heap memory
-  void releaseMemory() {
-    std::vector<Pose>().swap(_poses);
-  }
+  void releaseMemory() { std::vector<Pose>().swap(_poses); }
 
   double distance() const {
     double distance = 0.0;
@@ -84,12 +74,7 @@ class Trajectory {
     return distance;
   }
 
-  double displacement() const
-    {
-      return (_poses.size() < 2)
-            ? 0.0
-            : (_poses.back().position() - _poses.front().position()).norm();
-    }
+  double displacement() const { return (_poses.size() < 2) ? 0.0 : (_poses.back().position() - _poses.front().position()).norm(); }
 
   bool isStanding(double rate, double seconds, double noMovementThreshold) const {
     size_t required_size = static_cast<size_t>(rate * seconds);
@@ -112,13 +97,11 @@ class Trajectory {
   // Cut the trajectory to the time window [startTime, endTime]
   void cutTrajectory(double startTime, double endTime) {
     // Remove poses before startTime
-    auto firstPose = std::find_if(_poses.begin(), _poses.end(),
-                                  [startTime](const Pose& pose) { return pose.time() >= startTime; });
+    auto firstPose = std::find_if(_poses.begin(), _poses.end(), [startTime](const Pose& pose) { return pose.time() >= startTime; });
     _poses.erase(_poses.begin(), firstPose);
 
     // Remove poses after endTime
-    auto lastPose = std::find_if(_poses.begin(), _poses.end(),
-                                 [endTime](const Pose& pose) { return pose.time() > endTime; });
+    auto lastPose = std::find_if(_poses.begin(), _poses.end(), [endTime](const Pose& pose) { return pose.time() > endTime; });
     _poses.erase(lastPose, _poses.end());
   }
 
@@ -138,7 +121,7 @@ class Trajectory {
 
   Eigen::Vector3d _filteredPos = Eigen::Vector3d::Zero();
   Eigen::Vector3d _filteredCov = Eigen::Vector3d::Zero();
-  double          _lastTime    = 0.0;
+  double _lastTime = 0.0;
 };
 
 }  // namespace graph_msf

--- a/graph_msf/include/graph_msf/gnss/GnssCovariance.h
+++ b/graph_msf/include/graph_msf/gnss/GnssCovariance.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <Eigen/Dense>
-#include <cmath>
 #include <algorithm>  // for std::max
+#include <cmath>
 #include "graph_msf/gnss/GnssHandler.h"
 
 namespace graph_msf {
@@ -9,11 +9,11 @@ namespace gnss_cov {
 
 /** WGS-84 auxiliary radii at latitude lat_rad and height h [m] */
 inline void wgs84Radii(double lat_rad, double h, double& M, double& N) {
-  constexpr double a  = 6378137.0;                 // semi-major [m]
-  constexpr double f  = 1.0 / 298.257223563;       // flattening
-  const double e2 = f * (2.0 - f);                 // eccentricity^2
-  const double s  = std::sin(lat_rad);
-  const double d  = 1.0 - e2 * s * s;
+  constexpr double a = 6378137.0;            // semi-major [m]
+  constexpr double f = 1.0 / 298.257223563;  // flattening
+  const double e2 = f * (2.0 - f);           // eccentricity^2
+  const double s = std::sin(lat_rad);
+  const double d = 1.0 - e2 * s * s;
   N = a / std::sqrt(d);
   M = a * (1.0 - e2) / std::pow(d, 1.5);
 }
@@ -24,11 +24,12 @@ inline void wgs84Radii(double lat_rad, double h, double& M, double& N) {
  */
 inline Eigen::Matrix3d J_lla_wrt_enu(double lat_deg, double h_m) {
   const double lat = lat_deg * M_PI / 180.0;
-  double M, N; wgs84Radii(lat, h_m, M, N);
+  double M, N;
+  wgs84Radii(lat, h_m, M, N);
   Eigen::Matrix3d J = Eigen::Matrix3d::Zero();
-  J(0,1) = (180.0 / M_PI) / (M + h_m);                      // dlat/dN [deg/m]
-  J(1,0) = (180.0 / M_PI) / ((N + h_m) * std::cos(lat));    // dlon/dE [deg/m]
-  J(2,2) = 1.0;                                             // dalt/dU
+  J(0, 1) = (180.0 / M_PI) / (M + h_m);                    // dlat/dN [deg/m]
+  J(1, 0) = (180.0 / M_PI) / ((N + h_m) * std::cos(lat));  // dlon/dE [deg/m]
+  J(2, 2) = 1.0;                                           // dalt/dU
   return J;
 }
 
@@ -37,12 +38,12 @@ inline Eigen::Matrix3d J_lla_wrt_enu(double lat_deg, double h_m) {
  * Computed by central differences using your existing converter.
  * NOTE: GnssHandler is intentionally non-const (converter is non-const).
  */
-inline Eigen::Matrix3d J_lv03_wrt_lla(graph_msf::GnssHandler& gh,
-                                      double lat_deg, double lon_deg, double alt_m) {
-  const double ddeg = 1e-6; // ~0.11 m in latitude; small but stable
+inline Eigen::Matrix3d J_lv03_wrt_lla(graph_msf::GnssHandler& gh, double lat_deg, double lon_deg, double alt_m) {
+  const double ddeg = 1e-6;  // ~0.11 m in latitude; small but stable
   const Eigen::Vector3d lla(lat_deg, lon_deg, alt_m);
 
-  Eigen::Vector3d p0; gh.convertNavSatToPositionLV03(lla, p0);
+  Eigen::Vector3d p0;
+  gh.convertNavSatToPositionLV03(lla, p0);
 
   // d/d(lat)
   Eigen::Vector3d p_p, p_m;
@@ -57,29 +58,29 @@ inline Eigen::Matrix3d J_lv03_wrt_lla(graph_msf::GnssHandler& gh,
 
   // Assemble: altitude passes through in your converter
   Eigen::Matrix3d J = Eigen::Matrix3d::Zero();
-  J(0,0) = d_lat(0); J(0,1) = d_lon(0);  // dE/dlat(deg), dE/dlon(deg)
-  J(1,0) = d_lat(1); J(1,1) = d_lon(1);  // dN/dlat(deg), dN/dlon(deg)
-  J(2,2) = 1.0;                           // dZ/dalt(m)
+  J(0, 0) = d_lat(0);
+  J(0, 1) = d_lon(0);  // dE/dlat(deg), dE/dlon(deg)
+  J(1, 0) = d_lat(1);
+  J(1, 1) = d_lon(1);  // dN/dlat(deg), dN/dlon(deg)
+  J(2, 2) = 1.0;       // dZ/dalt(m)
   return J;
 }
 
 /** Chain rule: A = d(LV03)/d(ENU) */
-inline Eigen::Matrix3d A_lv03_wrt_enu(graph_msf::GnssHandler& gh,
-                                      double lat_deg, double lon_deg, double alt_m) {
-  const Eigen::Matrix3d J1 = J_lv03_wrt_lla(gh, lat_deg, lon_deg, alt_m); // [m/deg, m/deg, m/m]
-  const Eigen::Matrix3d J2 = J_lla_wrt_enu(lat_deg, alt_m);               // [deg/m, deg/m, m/m]
-  return J1 * J2; // [m/m]
+inline Eigen::Matrix3d A_lv03_wrt_enu(graph_msf::GnssHandler& gh, double lat_deg, double lon_deg, double alt_m) {
+  const Eigen::Matrix3d J1 = J_lv03_wrt_lla(gh, lat_deg, lon_deg, alt_m);  // [m/deg, m/deg, m/m]
+  const Eigen::Matrix3d J2 = J_lla_wrt_enu(lat_deg, alt_m);                // [deg/m, deg/m, m/m]
+  return J1 * J2;                                                          // [m/m]
 }
 
 /** Rotate covariance from ENU to LV03 at the given fix. Returns PSD, symmetrized. */
-inline Eigen::Matrix3d rotateCov_ENU_to_LV03(graph_msf::GnssHandler& gh,
-                                             double lat_deg, double lon_deg, double alt_m,
+inline Eigen::Matrix3d rotateCov_ENU_to_LV03(graph_msf::GnssHandler& gh, double lat_deg, double lon_deg, double alt_m,
                                              const Eigen::Matrix3d& P_enu) {
   const Eigen::Matrix3d A = A_lv03_wrt_enu(gh, lat_deg, lon_deg, alt_m);
   Eigen::Matrix3d P = A * P_enu * A.transpose();
   // Hygiene
   P = 0.5 * (P + P.transpose());
-  for (int i = 0; i < 3; ++i) P(i,i) = std::max(P(i,i), 1e-12); // clamp to >= 1e-12 m^2
+  for (int i = 0; i < 3; ++i) P(i, i) = std::max(P(i, i), 1e-12);  // clamp to >= 1e-12 m^2
   return P;
 }
 
@@ -95,8 +96,8 @@ inline bool selfCheckA(graph_msf::GnssHandler& gh, double lat_deg, double lon_de
   const Eigen::Matrix3d A = A_lv03_wrt_enu(gh, lat_deg, lon_deg, alt_m);
 
   // Finite-diff columns via small ENU displacements
-  const double eps = 0.1; // 10 cm
-  auto toLV03 = [&](double dE, double dN, double dU)->Eigen::Vector3d {
+  const double eps = 0.1;  // 10 cm
+  auto toLV03 = [&](double dE, double dN, double dU) -> Eigen::Vector3d {
     // ENU->LLA (linearized)
     Eigen::Matrix3d J = J_lla_wrt_enu(lat_deg, alt_m);
     Eigen::Vector3d dlla = J * Eigen::Vector3d(dE, dN, dU);
@@ -106,13 +107,13 @@ inline bool selfCheckA(graph_msf::GnssHandler& gh, double lat_deg, double lon_de
     return p1 - p0;
   };
   Eigen::Matrix3d A_fd;
-  A_fd.col(0) = toLV03(eps,0,0)/eps;
-  A_fd.col(1) = toLV03(0,eps,0)/eps;
-  A_fd.col(2) = toLV03(0,0,eps)/eps;
+  A_fd.col(0) = toLV03(eps, 0, 0) / eps;
+  A_fd.col(1) = toLV03(0, eps, 0) / eps;
+  A_fd.col(2) = toLV03(0, 0, eps) / eps;
 
   const double rel = (A - A_fd).norm() / std::max(1.0, A.norm());
-  return rel < 1e-4; // typical ~1e-6 to 1e-7
+  return rel < 1e-4;  // typical ~1e-6 to 1e-7
 }
 
-} // namespace gnss_cov
-} // namespace graph_msf
+}  // namespace gnss_cov
+}  // namespace graph_msf

--- a/graph_msf/include/graph_msf/imu/ImuSignalLowPassFilter.hpp
+++ b/graph_msf/include/graph_msf/imu/ImuSignalLowPassFilter.hpp
@@ -8,14 +8,14 @@ Please see the LICENSE file that has been included as part of this package.
 #ifndef GRAPH_MSF_IMU_IMU_SIGNAL_LOW_PASS_FILTER_HPP
 #define GRAPH_MSF_IMU_IMU_SIGNAL_LOW_PASS_FILTER_HPP
 
-#include <cmath>
 #include <Eigen/Dense>
+#include <cmath>
 
 namespace graph_msf {
 
 /**
  * @brief Second-order Butterworth low-pass filter for IMU signals
- * 
+ *
  * This filter provides superior characteristics compared to first-order filters:
  * - Steeper roll-off (40 dB/decade vs 20 dB/decade)
  * - Maximally flat passband response
@@ -32,20 +32,23 @@ class ImuSignalLowPassFilter {
   void setFilterParameters(double cutoffFrequencyHz, double samplingTime) {
     cutoffFrequencyHz_ = cutoffFrequencyHz;
     samplingTime_ = samplingTime;
-    
+
     // Calculate second-order Butterworth filter coefficients
     // Using bilinear transform (Tustin's method) for stability
     const double nyquistFreq = 1.0 / (2.0 * samplingTime_);
     const double normalizedCutoff = cutoffFrequencyHz_ / nyquistFreq;
-    
+
     // Prevent numerical issues for very high cutoff frequencies
     if (normalizedCutoff >= 1.0) {
       // If cutoff is at or above Nyquist frequency, disable filtering
-      b0_ = 1.0; b1_ = 0.0; b2_ = 0.0;
-      a1_ = 0.0; a2_ = 0.0;
+      b0_ = 1.0;
+      b1_ = 0.0;
+      b2_ = 0.0;
+      a1_ = 0.0;
+      a2_ = 0.0;
       return;
     }
-    
+
     // Second-order Butterworth filter design
     const double wc = std::tan(M_PI * normalizedCutoff);
     const double wc2 = wc * wc;
@@ -53,7 +56,7 @@ class ImuSignalLowPassFilter {
     const double k1 = sqrt2 * wc;
     const double k2 = wc2;
     const double a0 = k2 + k1 + 1.0;
-    
+
     // Normalized coefficients
     b0_ = k2 / a0;
     b1_ = 2.0 * k2 / a0;
@@ -68,7 +71,7 @@ class ImuSignalLowPassFilter {
     x2_accel_ = Eigen::Vector3d::Zero();
     y1_accel_ = Eigen::Vector3d::Zero();
     y2_accel_ = Eigen::Vector3d::Zero();
-    
+
     // Reset angular velocity filter state
     x1_gyro_ = Eigen::Vector3d::Zero();
     x2_gyro_ = Eigen::Vector3d::Zero();
@@ -79,7 +82,7 @@ class ImuSignalLowPassFilter {
   Eigen::Matrix<double, 6, 1> filter(const Eigen::Vector3d& inputAcceleration_x0, const Eigen::Vector3d& inputAngularVel_x0) {
     // Apply second-order filter to acceleration
     Eigen::Vector3d outputAcceleration = applyFilter(inputAcceleration_x0, x1_accel_, x2_accel_, y1_accel_, y2_accel_);
-    
+
     // Apply second-order filter to angular velocity
     Eigen::Vector3d outputAngularVel = applyFilter(inputAngularVel_x0, x1_gyro_, x2_gyro_, y1_gyro_, y2_gyro_);
 
@@ -92,7 +95,7 @@ class ImuSignalLowPassFilter {
    * @return Cutoff frequency in Hz
    */
   double getCutoffFrequency() const { return cutoffFrequencyHz_; }
-  
+
   /**
    * @brief Get the sampling time
    * @return Sampling time in seconds
@@ -109,41 +112,40 @@ class ImuSignalLowPassFilter {
    * @param y2 Second previous output sample (updated)
    * @return Filtered output
    */
-  Eigen::Vector3d applyFilter(const Eigen::Vector3d& input, 
-                             Eigen::Vector3d& x1, Eigen::Vector3d& x2,
-                             Eigen::Vector3d& y1, Eigen::Vector3d& y2) {
+  Eigen::Vector3d applyFilter(const Eigen::Vector3d& input, Eigen::Vector3d& x1, Eigen::Vector3d& x2, Eigen::Vector3d& y1,
+                              Eigen::Vector3d& y2) {
     // Direct Form II implementation of second-order filter
     // y[n] = b0*x[n] + b1*x[n-1] + b2*x[n-2] - a1*y[n-1] - a2*y[n-2]
     Eigen::Vector3d output = b0_ * input + b1_ * x1 + b2_ * x2 - a1_ * y1 - a2_ * y2;
-    
+
     // Update state variables
     x2 = x1;
     x1 = input;
     y2 = y1;
     y1 = output;
-    
+
     return output;
   }
 
   // Filter parameters
   double cutoffFrequencyHz_;
   double samplingTime_;
-  
+
   // Filter coefficients (second-order Butterworth)
   double b0_, b1_, b2_;  // Numerator coefficients
-  double a1_, a2_;      // Denominator coefficients (a0 = 1)
-  
+  double a1_, a2_;       // Denominator coefficients (a0 = 1)
+
   // Filter state for acceleration (3D)
   Eigen::Vector3d x1_accel_ = Eigen::Vector3d::Zero();  // Previous input
   Eigen::Vector3d x2_accel_ = Eigen::Vector3d::Zero();  // Second previous input
   Eigen::Vector3d y1_accel_ = Eigen::Vector3d::Zero();  // Previous output
   Eigen::Vector3d y2_accel_ = Eigen::Vector3d::Zero();  // Second previous output
-  
+
   // Filter state for angular velocity (3D)
-  Eigen::Vector3d x1_gyro_ = Eigen::Vector3d::Zero();   // Previous input
-  Eigen::Vector3d x2_gyro_ = Eigen::Vector3d::Zero();   // Second previous input
-  Eigen::Vector3d y1_gyro_ = Eigen::Vector3d::Zero();   // Previous output
-  Eigen::Vector3d y2_gyro_ = Eigen::Vector3d::Zero();   // Second previous output
+  Eigen::Vector3d x1_gyro_ = Eigen::Vector3d::Zero();  // Previous input
+  Eigen::Vector3d x2_gyro_ = Eigen::Vector3d::Zero();  // Second previous input
+  Eigen::Vector3d y1_gyro_ = Eigen::Vector3d::Zero();  // Previous output
+  Eigen::Vector3d y2_gyro_ = Eigen::Vector3d::Zero();  // Second previous output
 };
 
 }  // namespace graph_msf

--- a/graph_msf/include/graph_msf/interface/constants.h
+++ b/graph_msf/include/graph_msf/interface/constants.h
@@ -10,6 +10,9 @@ Please see the LICENSE file that has been included as part of this package.
 #ifndef GRAPH_MSF_CONSTANTS_H
 #define GRAPH_MSF_CONSTANTS_H
 
+#ifdef REGULAR_COUT
+#undef REGULAR_COUT
+#endif
 #define REGULAR_COUT std::cout << YELLOW_START << "GraphMsf" << COLOR_END
 
 #endif  // GRAPH_MSF_CONSTANTS_H

--- a/graph_msf/include/graph_msf/interface/eigen_wrapped_gtsam_utils.h
+++ b/graph_msf/include/graph_msf/interface/eigen_wrapped_gtsam_utils.h
@@ -31,7 +31,7 @@ void createLatLonAltCsvFileStream(std::map<std::string, std::ofstream>& fileStre
 // Pose 3
 void writePose3ToCsvFile(std::map<std::string, std::ofstream>& fileStreams, const Eigen::Isometry3d pose,
                          const std::string& transformIdentifier, const double timeStamp, const bool saveCovarianceFlag,
-                         boost::optional<const Eigen::Matrix<double, 6, 6>&> optionalPoseCovarianceInWorldRos = boost::none);
+                         const Eigen::Matrix<double, 6, 6>* optionalPoseCovarianceInWorldRos = nullptr);
 // Latitude, Longitude, Altitude
 void writeLatLonAltToCsvFile(std::map<std::string, std::ofstream>& fileStreams, const Eigen::Vector3d& latLonAlt,
                              const std::string& transformIdentifier, const double timeStamp);

--- a/graph_msf/include/graph_msf/trajectory_alignment/TrajectoryAlignment.h
+++ b/graph_msf/include/graph_msf/trajectory_alignment/TrajectoryAlignment.h
@@ -25,19 +25,19 @@ namespace graph_msf {
 
 class TrajectoryAlignment {
  public:
+  template <typename Vec, typename T>
+  inline Vec lerp(const Vec& a, const Vec& b, T t) {
+    return a + t * (b - a);
+  }
 
-  template<typename Vec, typename T>
-  inline Vec lerp(const Vec& a, const Vec& b, T t) { return a + t*(b - a); }
-
-  Trajectory resample(const Trajectory& src, double t0, double dt, size_t N)
-  {
+  Trajectory resample(const Trajectory& src, double t0, double dt, size_t N) {
     Trajectory dst;
     size_t i = 0;
     for (size_t k = 0; k < N; ++k) {
-      double tk = t0 + k*dt;
-      while (i+1 < src.poses().size() && src.poses()[i+1].time() < tk) ++i;
+      double tk = t0 + k * dt;
+      while (i + 1 < src.poses().size() && src.poses()[i + 1].time() < tk) ++i;
       const auto& p0 = src.poses()[i];
-      const auto& p1 = src.poses()[i+1];
+      const auto& p1 = src.poses()[i + 1];
       double u = (tk - p0.time()) / (p1.time() - p0.time());
       dst.addPose(lerp(p0.position(), p1.position(), u), tk);
     }
@@ -51,7 +51,7 @@ class TrajectoryAlignment {
   void addR3Position(Eigen::Vector3d position, double time);
   void addR3PositionWithStdDev(Eigen::Vector3d position, double time, Eigen::Vector3d stdDev);
   bool alignTrajectories(double& yaw, Eigen::Isometry3d& returnTransform);
-  
+
   // Setters
   void setR3Rate(const double r3Rate) { r3Rate_ = r3Rate; }
   void setSe3Rate(const double se3Rate) { se3Rate_ = se3Rate; }
@@ -65,17 +65,12 @@ class TrajectoryAlignment {
 
  private:
   // Member methods
-  bool associateTrajectories(const Trajectory& trajectoryA, const Trajectory& trajectoryB, Trajectory& newTrajectoryA, Trajectory& newTrajectoryB);
+  bool associateTrajectories(const Trajectory& trajectoryA, const Trajectory& trajectoryB, Trajectory& newTrajectoryA,
+                             Trajectory& newTrajectoryB);
   bool hasMinimumSpatialSpread(const std::vector<Pose>& poses, double kMinSpread);
   bool trajectoryAlignment(Trajectory& trajectoryA, Trajectory& trajectoryB, Eigen::Isometry3d& returnTransform);
-  bool trajectoryAlignmentRobust(
-          const Trajectory&  trajectoryA,
-          const Trajectory&  trajectoryB,
-          Eigen::Isometry3d& returnTransform,
-          double             inlierThreshold,
-          double             ransacConfidence,
-          std::size_t        maxIterations,
-          bool               withScaling);
+  bool trajectoryAlignmentRobust(const Trajectory& trajectoryA, const Trajectory& trajectoryB, Eigen::Isometry3d& returnTransform,
+                                 double inlierThreshold, double ransacConfidence, std::size_t maxIterations, bool withScaling);
 
   // Member variables
   Trajectory r3Trajectory_;

--- a/graph_msf/src/lib/FileLogger.cpp
+++ b/graph_msf/src/lib/FileLogger.cpp
@@ -13,6 +13,9 @@ Please see the LICENSE file that has been included as part of this package.
 
 // Output
 #include "graph_msf/interface/constants.h"
+#ifdef REGULAR_COUT
+#undef REGULAR_COUT
+#endif
 #define REGULAR_COUT std::cout << YELLOW_START << "GMSF-TransformExpressionKeys" << COLOR_END
 
 namespace graph_msf {

--- a/graph_msf/src/lib/FileLogger.cpp
+++ b/graph_msf/src/lib/FileLogger.cpp
@@ -130,7 +130,7 @@ void FileLogger::createPose3TumFileStream(std::map<std::string, std::ofstream>& 
 // Pose3
 void FileLogger::writePose3ToCsvFile(std::map<std::string, std::ofstream>& fileStreams, const gtsam::Pose3& pose,
                                      const std::string& transformIdentifier, const double timeStamp, const bool saveCovarianceFlag,
-                                     boost::optional<const Eigen::Matrix<double, 6, 6>&> optionalPoseCovarianceInWorldRos) {
+                                     const Eigen::Matrix<double, 6, 6>* optionalPoseCovarianceInWorldRos) {
   fileStreams[transformIdentifier] << std::setprecision(14) << timeStamp << ", " << pose.x() << ", " << pose.y() << ", " << pose.z() << ", "
                                    << pose.rotation().toQuaternion().x() << ", " << pose.rotation().toQuaternion().y() << ", "
                                    << pose.rotation().toQuaternion().z() << ", " << pose.rotation().toQuaternion().w() << ", "
@@ -140,7 +140,7 @@ void FileLogger::writePose3ToCsvFile(std::map<std::string, std::ofstream>& fileS
     if (!optionalPoseCovarianceInWorldRos) {
       throw std::runtime_error("FileLogger: Pose covariance not provided for writing to file.");
     } else {
-      const auto& poseCovarianceInWorldRos = optionalPoseCovarianceInWorldRos.value();
+      const auto& poseCovarianceInWorldRos = *optionalPoseCovarianceInWorldRos;
       fileStreams[transformIdentifier + "_covariance"]
           << std::setprecision(14) << timeStamp << ", " << poseCovarianceInWorldRos(0, 0) << ", " << poseCovarianceInWorldRos(0, 1) << ", "
           << poseCovarianceInWorldRos(0, 2) << ", " << poseCovarianceInWorldRos(0, 3) << ", " << poseCovarianceInWorldRos(0, 4) << ", "

--- a/graph_msf/src/lib/GraphManager.cpp
+++ b/graph_msf/src/lib/GraphManager.cpp
@@ -32,6 +32,9 @@ Please see the LICENSE file that has been included as part of this package.
 #include "graph_msf/core/optimizer/OptimizerLMBatch.hpp"
 #include "graph_msf/core/optimizer/OptimizerLMFixedLag.hpp"
 
+#ifdef REGULAR_COUT
+#undef REGULAR_COUT
+#endif
 #define REGULAR_COUT std::cout << YELLOW_START << "GMSF-GraphManager" << COLOR_END
 
 namespace graph_msf {
@@ -225,7 +228,7 @@ void GraphManager::addImuFactorAndGetState(SafeIntegratedNavState& returnPreInte
         imuBufferPtr->integrateNavStateFromTimestamp(imuMeas.begin()->first, imuMeas.rbegin()->first, W_imuPropagatedState_,
                                                      gtsam::imuBias::ConstantBias(), graphConfigPtr_->W_gravityVector_);
   }
-  
+
   // 1.4 Propagate to state in odom
   // Delta pose
   const gtsam::Pose3 T_W_I_afterInt = W_imuPropagatedState_.pose();
@@ -327,10 +330,8 @@ void GraphManager::addImuFactorAndGetState(SafeIntegratedNavState& returnPreInte
 
 // Set T_W_F
 bool GraphManager::setInitialWorldFrameToFixedFrameTransform(const Eigen::Isometry3d& T_W_F, const std::string& fixedFrame) {
-  gtsamDynamicExpressionKeys_.get<gtsam::Pose3>()
-          .setInitialGuessForFramePair(worldFrame_, fixedFrame, gtsam::Pose3(T_W_F.matrix()));
-  std::cout << " Set world to fixed frame transform T_" << worldFrame_ << "_" << fixedFrame << " to: " << T_W_F.matrix()
-            << std::endl;
+  gtsamDynamicExpressionKeys_.get<gtsam::Pose3>().setInitialGuessForFramePair(worldFrame_, fixedFrame, gtsam::Pose3(T_W_F.matrix()));
+  std::cout << " Set world to fixed frame transform T_" << worldFrame_ << "_" << fixedFrame << " to: " << T_W_F.matrix() << std::endl;
   return true;
 }
 
@@ -775,8 +776,8 @@ void GraphManager::updateGraph() {
             }
           }
         }  // catch statement
-      }    // end: if active statement
-    }      // for loop over all transforms
+      }  // end: if active statement
+    }  // for loop over all transforms
   }
 
   // Mutex block 2 ------------------

--- a/graph_msf/src/lib/GraphManager.cpp
+++ b/graph_msf/src/lib/GraphManager.cpp
@@ -399,7 +399,7 @@ gtsam::Key GraphManager::addPoseBetweenFactor(const gtsam::Pose3& deltaPose, con
   // Create noise model
   assert(poseBetweenNoiseDensity.size() == 6);
   auto noise = gtsam::noiseModel::Diagonal::Sigmas((gtsam::Vector(poseBetweenNoiseDensity)));  // rad,rad,rad,m,m,m
-  boost::shared_ptr<gtsam::noiseModel::Robust> robustErrorFunction;
+  gtsam::noiseModel::Robust::shared_ptr robustErrorFunction;
   // Pick Robust Error Function
   switch (robustNormEnum) {
     case RobustNormEnum::Huber:
@@ -1124,7 +1124,8 @@ void GraphManager::saveOptimizedValuesToFile(const gtsam::Values& optimizedValue
 
     // Write the values to the appropriate file
     // CSV file for Pose3
-    fileLogger_.writePose3ToCsvFile(fileStreams, pose, transformIdentifier, timeStamp, saveCovarianceFlag, poseCovarianceInWorldRos);
+    fileLogger_.writePose3ToCsvFile(fileStreams, pose, transformIdentifier, timeStamp, saveCovarianceFlag,
+                                    saveCovarianceFlag ? &poseCovarianceInWorldRos : nullptr);
     // TUM file for Pose3
     fileLogger_.writePose3ToTumFile(fileStreams, pose, transformIdentifier + "_tum", timeStamp);
   }  // end of for loop over all pose states

--- a/graph_msf/src/lib/GraphManager.cpp
+++ b/graph_msf/src/lib/GraphManager.cpp
@@ -1277,6 +1277,9 @@ bool GraphManager::addFactorsToRtSmootherAndOptimize(const gtsam::NonlinearFacto
   bool successFlag = rtOptimizerPtr_->update(newRtGraphFactors, newRtGraphValues, newRtGraphKeysTimestampsMap);
   // Additional iterations
   for (size_t itr = 0; itr < additionalIterations; ++itr) {
+    if (!successFlag) {
+      break;
+    }
     successFlag = successFlag && rtOptimizerPtr_->update();
   }
 

--- a/graph_msf/src/lib/GraphManager.cpp
+++ b/graph_msf/src/lib/GraphManager.cpp
@@ -583,6 +583,12 @@ void GraphManager::updateGraph() {
   // A. NavState ------------------------------
   gtsam::NavState resultNavState =
       calculateNavStateAtGeneralKey(successfulOptimizationFlag, rtOptimizerPtr_, currentPropagatedKey, __func__);
+  if (!successfulOptimizationFlag) {
+    REGULAR_COUT << RED_START << " Skipping result extraction for marginalized key "
+                 << gtsam::Symbol(gtsam::symbol_shorthand::X(currentPropagatedKey))
+                 << " after fixed-lag optimization." << COLOR_END << std::endl;
+    return;
+  }
   rtOptimizerPtr_->addLatestPoseBelief(resultNavState.pose());
   // B. Bias ------------------------------
   gtsam::imuBias::ConstantBias resultBias = rtOptimizerPtr_->calculateEstimatedBias(gtsam::symbol_shorthand::B(currentPropagatedKey));

--- a/graph_msf/src/lib/GraphMsf.cpp
+++ b/graph_msf/src/lib/GraphMsf.cpp
@@ -115,9 +115,6 @@ bool GraphMsf::initYawAndPositionInWorld(const double yaw_fixedFrame_frame1, con
     Eigen::Vector3d W_t_W_I0 =
         W_t_W_Frame1_to_W_t_W_Frame2_(fixedFrame_t_fixedFrame_frame2, frame2, staticTransformsPtr_->getImuFrame(), R_W_I0);
 
-
-    
-
     // Set Position
     preIntegratedNavStatePtr_->updatePositionInWorld(W_t_W_I0, graphConfigPtr_->odomNotJumpAtStartFlag_);
 

--- a/graph_msf/src/lib/GraphMsfClassic.cpp
+++ b/graph_msf/src/lib/GraphMsfClassic.cpp
@@ -15,8 +15,8 @@ Please see the LICENSE file that has been included as part of this package.
 #include "graph_msf/core/GraphManager.h"
 
 // Unary Factors
-#include "graph_msf/factors/non_expression/unaryRollFactor.h"
 #include "graph_msf/factors/non_expression/unaryPitchFactor.h"
+#include "graph_msf/factors/non_expression/unaryRollFactor.h"
 #include "graph_msf/factors/non_expression/unaryYawFactor.h"
 
 namespace graph_msf {
@@ -53,9 +53,8 @@ void GraphMsfClassic::addUnaryYawAbsoluteMeasurement(const UnaryMeasurementXDAbs
       optimizeGraphFlag_ = true;
     }
   } else {
-    std::cout << YELLOW_START << "GMsf-Classic" << RED_START
-              << " Covariance violation detected in yaw unary measurement at time " << yaw_W_frame.timeK()
-              << ". Measurement not added to graph." << COLOR_END << std::endl;
+    std::cout << YELLOW_START << "GMsf-Classic" << RED_START << " Covariance violation detected in yaw unary measurement at time "
+              << yaw_W_frame.timeK() << ". Measurement not added to graph." << COLOR_END << std::endl;
   }
 }
 
@@ -85,9 +84,8 @@ void GraphMsfClassic::addUnaryRollAbsoluteMeasurement(const UnaryMeasurementXDAb
       optimizeGraphFlag_ = true;
     }
   } else {
-    std::cout << YELLOW_START << "GMsf-Classic" << RED_START
-              << " Covariance violation detected in roll unary measurement at time " << roll_W_frame.timeK()
-              << ". Measurement not added to graph." << COLOR_END << std::endl;
+    std::cout << YELLOW_START << "GMsf-Classic" << RED_START << " Covariance violation detected in roll unary measurement at time "
+              << roll_W_frame.timeK() << ". Measurement not added to graph." << COLOR_END << std::endl;
   }
 }
 
@@ -105,7 +103,8 @@ void GraphMsfClassic::addUnaryPitchAbsoluteMeasurement(const UnaryMeasurementXDA
   gtsam::Rot3 pitchR_W_frame = gtsam::Rot3::Pitch(pitch_W_frame.unaryMeasurement());
   gtsam::Rot3 pitchR_W_I =
       pitchR_W_frame *
-      gtsam::Rot3(staticTransformsPtr_->rv_T_frame1_frame2(pitch_W_frame.sensorFrameName(), staticTransformsPtr_->getImuFrame()).rotation());
+      gtsam::Rot3(
+          staticTransformsPtr_->rv_T_frame1_frame2(pitch_W_frame.sensorFrameName(), staticTransformsPtr_->getImuFrame()).rotation());
 
   // Add factor
   if (!covarianceViolatedFlag) {
@@ -117,9 +116,8 @@ void GraphMsfClassic::addUnaryPitchAbsoluteMeasurement(const UnaryMeasurementXDA
       optimizeGraphFlag_ = true;
     }
   } else {
-    std::cout << YELLOW_START << "GMsf-Classic" << RED_START
-              << " Covariance violation detected in pitch unary measurement at time " << pitch_W_frame.timeK()
-              << ". Measurement not added to graph." << COLOR_END << std::endl;
+    std::cout << YELLOW_START << "GMsf-Classic" << RED_START << " Covariance violation detected in pitch unary measurement at time "
+              << pitch_W_frame.timeK() << ". Measurement not added to graph." << COLOR_END << std::endl;
   }
 }
 

--- a/graph_msf/src/lib/ImuBuffer.cpp
+++ b/graph_msf/src/lib/ImuBuffer.cpp
@@ -282,8 +282,7 @@ gtsam::NavState ImuBuffer::integrateNavStateFromTimestamp(const double& tsStart,
 
     // Update propagated state
     Eigen::Vector3d i_gravityVector = propagatedState.R().transpose() * W_gravityVector;
-    propagatedState =
-        propagatedState.update(i_gravityVector + i_measAcceleration, i_measAngularVelocity, dt, boost::none, boost::none, boost::none);
+    propagatedState = propagatedState.update(i_gravityVector + i_measAcceleration, i_measAngularVelocity, dt);
   }
   return propagatedState;
 }

--- a/graph_msf/src/lib/TrajectoryAlignment.cpp
+++ b/graph_msf/src/lib/TrajectoryAlignment.cpp
@@ -7,9 +7,9 @@ Please see the LICENSE file that has been included as part of this package.
 
 // C++
 #include <boost/optional.hpp>
+#include <iomanip>
 #include <iostream>
 #include <random>
-#include <iomanip>
 
 // Package
 #include "graph_msf/trajectory_alignment/TrajectoryAlignment.h"
@@ -58,12 +58,8 @@ void TrajectoryAlignment::addR3PositionWithStdDev(Eigen::Vector3d position, doub
   r3Trajectory_.addPoseWithFilter(position, time, stdDev);
 }
 
-bool TrajectoryAlignment::associateTrajectories(
-        const Trajectory& trajectoryA,
-        const Trajectory& trajectoryB,
-        Trajectory&       newTrajectoryA,
-        Trajectory&       newTrajectoryB)
-{
+bool TrajectoryAlignment::associateTrajectories(const Trajectory& trajectoryA, const Trajectory& trajectoryB, Trajectory& newTrajectoryA,
+                                                Trajectory& newTrajectoryB) {
   newTrajectoryA.clear();
   newTrajectoryB.clear();
 
@@ -74,21 +70,18 @@ bool TrajectoryAlignment::associateTrajectories(
   std::size_t i = 0;
   std::size_t j = 0;
 
-  while (i < posesA.size() && j < posesB.size())
-  {
+  while (i < posesA.size() && j < posesB.size()) {
     const double tA = posesA[i].time();
     const double tB = posesB[j].time();
     const double dt = tA - tB;
 
-    if (std::fabs(dt) <= 0.15)
-    {
+    if (std::fabs(dt) <= 0.15) {
       // one-to-one correspondence found
       newTrajectoryA.addPose(posesA[i]);
       newTrajectoryB.addPose(posesB[j]);
-      ++i; ++j;
-    }
-    else
-    {
+      ++i;
+      ++j;
+    } else {
       // advance the trajectory that is behind in time
       (dt < 0.0) ? ++i : ++j;
     }
@@ -96,7 +89,6 @@ bool TrajectoryAlignment::associateTrajectories(
 
   return newTrajectoryA.poses().size() >= 3;
 }
-
 
 bool TrajectoryAlignment::trajectoryAlignment(Trajectory& trajectoryA, Trajectory& trajectoryB, Eigen::Isometry3d& returnTransform) {
   // Fill matrices to use Eigen Umeyama function
@@ -122,20 +114,13 @@ bool TrajectoryAlignment::trajectoryAlignment(Trajectory& trajectoryA, Trajector
   return true;
 }
 
-bool TrajectoryAlignment::trajectoryAlignmentRobust(
-        const Trajectory&  trajectoryA,
-        const Trajectory&  trajectoryB,
-        Eigen::Isometry3d& returnTransform,
-        double             inlierThreshold,   // [m]
-        double             ransacConfidence,
-        std::size_t        maxIterations,
-        bool               withScaling)
-{
+bool TrajectoryAlignment::trajectoryAlignmentRobust(const Trajectory& trajectoryA, const Trajectory& trajectoryB,
+                                                    Eigen::Isometry3d& returnTransform,
+                                                    double inlierThreshold,  // [m]
+                                                    double ransacConfidence, std::size_t maxIterations, bool withScaling) {
   // 1. quick sanity checks
-  const std::size_t N = std::min(trajectoryA.poses().size(),
-                                 trajectoryB.poses().size());
-  if (N < 3)
-    return false;
+  const std::size_t N = std::min(trajectoryA.poses().size(), trajectoryB.poses().size());
+  if (N < 3) return false;
 
   Eigen::Matrix3Xd A(3, N), B(3, N);
   for (std::size_t i = 0; i < N; ++i) {
@@ -144,14 +129,11 @@ bool TrajectoryAlignment::trajectoryAlignmentRobust(
   }
 
   // Helper lambdas
-  auto umeyama3 = [&](const Eigen::Matrix3Xd& P,
-                      const Eigen::Matrix3Xd& Q) -> Eigen::Isometry3d {
+  auto umeyama3 = [&](const Eigen::Matrix3Xd& P, const Eigen::Matrix3Xd& Q) -> Eigen::Isometry3d {
     return Eigen::Isometry3d(Eigen::umeyama(P, Q, withScaling));
   };
 
-  auto nonCollinear = [](const Eigen::Vector3d& a,
-                         const Eigen::Vector3d& b,
-                         const Eigen::Vector3d& c) -> bool {
+  auto nonCollinear = [](const Eigen::Vector3d& a, const Eigen::Vector3d& b, const Eigen::Vector3d& c) -> bool {
     return ((b - a).cross(c - a)).squaredNorm() > 1e-9;
   };
 
@@ -159,10 +141,10 @@ bool TrajectoryAlignment::trajectoryAlignmentRobust(
   std::uniform_int_distribution<std::size_t> uni(0, N - 1);
 
   std::vector<std::size_t> bestInliers;
-  Eigen::Isometry3d        bestT = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d bestT = Eigen::Isometry3d::Identity();
 
   const std::size_t sampleSize = 3;
-  std::size_t       iter       = 0;
+  std::size_t iter = 0;
   const double eps = std::numeric_limits<double>::epsilon();
 
   while (iter < maxIterations) {
@@ -199,18 +181,15 @@ bool TrajectoryAlignment::trajectoryAlignmentRobust(
       double p_no_outliers = 1.0 - std::pow(inlierRatio, sampleSize);
       p_no_outliers = std::clamp(p_no_outliers, eps, 1.0 - eps);
       maxIterations =
-          std::min<std::size_t>(maxIterations,
-              static_cast<std::size_t>(
-                  std::log(1.0 - ransacConfidence) / std::log(p_no_outliers)));
+          std::min<std::size_t>(maxIterations, static_cast<std::size_t>(std::log(1.0 - ransacConfidence) / std::log(p_no_outliers)));
     }
     ++iter;
   }
 
   if (bestInliers.size() < 3) {
     std::cerr << YELLOW_START << "Trajectory Alignment" << RED_START
-              << " Not enough inliers found for robust alignment: "
-              << bestInliers.size() << " inliers (need at least 3)."
-              << COLOR_END << std::endl;
+              << " Not enough inliers found for robust alignment: " << bestInliers.size() << " inliers (need at least 3)." << COLOR_END
+              << std::endl;
     return false;
   }
 
@@ -261,8 +240,8 @@ bool TrajectoryAlignment::trajectoryAlignmentRobust(
     Eigen::Vector3d t = muA - s * R * muB;
 
     Eigen::Matrix4d M = Eigen::Matrix4d::Identity();
-    M.block<3,3>(0,0) = s * R;
-    M.block<3,1>(0,3) = t;
+    M.block<3, 3>(0, 0) = s * R;
+    M.block<3, 1>(0, 3) = t;
     returnTransform = Eigen::Isometry3d(M);
   }
   return true;
@@ -319,9 +298,7 @@ bool TrajectoryAlignment::alignTrajectories(double& yaw, Eigen::Isometry3d& retu
 
   // Check for standing still or first alignment
   if (copySe3Trajectory.isStanding(se3Rate_, noMovementTime_, noMovementDistance_) ||
-      copyR3Trajectory.isStanding(r3Rate_, noMovementTime_, noMovementDistance_) ||
-      firstAlignmentTryFlag_) 
-  {
+      copyR3Trajectory.isStanding(r3Rate_, noMovementTime_, noMovementDistance_) || firstAlignmentTryFlag_) {
     {
       const std::lock_guard<std::mutex> lock(alignmentMutex);
       se3Trajectory_.clear();
@@ -331,10 +308,10 @@ bool TrajectoryAlignment::alignTrajectories(double& yaw, Eigen::Isometry3d& retu
         firstAlignmentTryFlag_ = false;
       }
     }
-    std::cout << YELLOW_START << "Trajectory Alignment" << GREEN_START << " No movement detected. Trajectories cleared." << COLOR_END << std::endl;
+    std::cout << YELLOW_START << "Trajectory Alignment" << GREEN_START << " No movement detected. Trajectories cleared." << COLOR_END
+              << std::endl;
     return false;
   }
-
 
   // Status
   if (copyR3Trajectory.poses().size() % 5 == 0) {
@@ -353,14 +330,14 @@ bool TrajectoryAlignment::alignTrajectories(double& yaw, Eigen::Isometry3d& retu
 
   double kMinSpread = 0.05;  // Minimum spatial spread in meters
   if (!hasMinimumSpatialSpread(copyR3Trajectory.poses(), kMinSpread)) {
-    std::cerr << YELLOW_START << "Trajectory Alignment" << RED_START
-              << " Minimum spatial spread check failed for R3 trajectory." << COLOR_END << std::endl;
+    std::cerr << YELLOW_START << "Trajectory Alignment" << RED_START << " Minimum spatial spread check failed for R3 trajectory."
+              << COLOR_END << std::endl;
     return false;
   }
 
   if (!hasMinimumSpatialSpread(copySe3Trajectory.poses(), kMinSpread)) {
-    std::cerr << YELLOW_START << "Trajectory Alignment" << RED_START
-              << " Minimum spatial spread check failed for SE3 trajectory." << COLOR_END << std::endl;
+    std::cerr << YELLOW_START << "Trajectory Alignment" << RED_START << " Minimum spatial spread check failed for SE3 trajectory."
+              << COLOR_END << std::endl;
     return false;
   }
 
@@ -369,12 +346,10 @@ bool TrajectoryAlignment::alignTrajectories(double& yaw, Eigen::Isometry3d& retu
 
   // Cutting of Timestamps Outside the Joint Time Window
   // Print the front and back times of both trajectories
-  std::cout << YELLOW_START << "Trajectory Alignment: SE3 time range [" 
-            << std::fixed << std::setprecision(9) << copySe3Trajectory.poses().front().time() << ", " 
-            << copySe3Trajectory.poses().back().time() << "]" << COLOR_END << std::endl;
-  std::cout << YELLOW_START << "Trajectory Alignment: R3 time range [" 
-            << std::fixed << std::setprecision(9) << copyR3Trajectory.poses().front().time() << ", " 
-            << copyR3Trajectory.poses().back().time() << "]" << COLOR_END << std::endl;
+  std::cout << YELLOW_START << "Trajectory Alignment: SE3 time range [" << std::fixed << std::setprecision(9)
+            << copySe3Trajectory.poses().front().time() << ", " << copySe3Trajectory.poses().back().time() << "]" << COLOR_END << std::endl;
+  std::cout << YELLOW_START << "Trajectory Alignment: R3 time range [" << std::fixed << std::setprecision(9)
+            << copyR3Trajectory.poses().front().time() << ", " << copyR3Trajectory.poses().back().time() << "]" << COLOR_END << std::endl;
 
   double startTime = std::max(copySe3Trajectory.poses().front().time(), copyR3Trajectory.poses().front().time());
   double endTime = std::min(copySe3Trajectory.poses().back().time(), copyR3Trajectory.poses().back().time());
@@ -437,10 +412,10 @@ bool TrajectoryAlignment::alignTrajectories(double& yaw, Eigen::Isometry3d& retu
 
   Eigen::Isometry3d att;
   bool ok = trajectoryAlignmentRobust(newR3Trajectory, newSe3Trajectory, alignmentTransform,
-                                              /*inlierThreshold*/0.15,
-                                              /*confidence*/0.999,
-                                              /*maxIter*/1000,
-                                              /*withScaling*/false);
+                                      /*inlierThreshold*/ 0.15,
+                                      /*confidence*/ 0.999,
+                                      /*maxIter*/ 1000,
+                                      /*withScaling*/ false);
   if (!ok) {
     std::cout << "TrajectoryAlignment::initializeYaw trajectoryAlignment failed." << std::endl;
     return false;

--- a/graph_msf/src/lib/eigen_wrapped_gtsam_utils.cpp
+++ b/graph_msf/src/lib/eigen_wrapped_gtsam_utils.cpp
@@ -52,7 +52,7 @@ void createLatLonAltCsvFileStream(std::map<std::string, std::ofstream>& fileStre
 // Pose 3
 void writePose3ToCsvFile(std::map<std::string, std::ofstream>& fileStreams, const Eigen::Isometry3d pose,
                          const std::string& transformIdentifier, const double timeStamp, const bool saveCovarianceFlag,
-                         boost::optional<const Eigen::Matrix<double, 6, 6>&> optionalPoseCovarianceInWorldRos) {
+                         const Eigen::Matrix<double, 6, 6>* optionalPoseCovarianceInWorldRos) {
   // Convert
   gtsam::Pose3 poseGtsam = gtsam::Pose3(pose.matrix());
   // Write to the file

--- a/ros2/graph_msf_ros2/CMakeLists.txt
+++ b/ros2/graph_msf_ros2/CMakeLists.txt
@@ -157,15 +157,25 @@ install(FILES
   DESTINATION share/${PROJECT_NAME}/cmake
 )
 
-# ##
-# # ROS2 Ament Package
-# ##
+##
+# ROS2 Ament Package
+##
 
-# # Export the package for ament
-# ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
-# ament_export_dependencies(
-#   graph_msf
-# )
+# Export the package for ament
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
+ament_export_dependencies(
+  graph_msf
+  geometry_msgs
+  nav_msgs
+  sensor_msgs
+  std_msgs
+  std_srvs
+  visualization_msgs
+  tf2
+  tf2_ros
+  tf2_eigen
+  rclcpp
+)
 
-# # Finish ament package setup
-# ament_package()
+# Finish ament package setup
+ament_package()

--- a/ros2/graph_msf_ros2/include/graph_msf_ros2/GraphMsfRos2.h
+++ b/ros2/graph_msf_ros2/include/graph_msf_ros2/GraphMsfRos2.h
@@ -160,6 +160,9 @@ class GraphMsfRos2 : public GraphMsfClassic, public GraphMsfHolistic, public rcl
   std::string optimizationResultLoggingPath = "";
 
  private:
+  // Topics
+  std::string imuTopic_ = "";
+
   // Publishers
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pubEstOdomImu_;
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pubEstWorldImu_;

--- a/ros2/graph_msf_ros2/include/graph_msf_ros2/constants.h
+++ b/ros2/graph_msf_ros2/include/graph_msf_ros2/constants.h
@@ -9,4 +9,7 @@ Please see the LICENSE file that has been included as part of this package.
 
 #pragma once
 
+#ifdef REGULAR_COUT
+#undef REGULAR_COUT
+#endif
 #define REGULAR_COUT std::cout << YELLOW_START << "GraphMsfRos2" << COLOR_END

--- a/ros2/graph_msf_ros2/include/graph_msf_ros2/ros/read_ros_params.h
+++ b/ros2/graph_msf_ros2/include/graph_msf_ros2/ros/read_ros_params.h
@@ -26,6 +26,15 @@ inline void printKey<std::vector<double>>(const std::string& key, const std::vec
   std::cout << std::endl;
 }
 
+template <>
+inline void printKey<std::vector<std::string>>(const std::string& key, const std::vector<std::string>& vec) {
+  std::cout << YELLOW_START << "GraphMsfRos2 " << COLOR_END << key << " set to: ";
+  for (size_t i = 0; i < vec.size(); ++i) {
+    std::cout << vec[i] << (i + 1 < vec.size() ? "," : "");
+  }
+  std::cout << std::endl;
+}
+
 // ---------- dumpAllParams ----------
 inline void dumpAllParams(const rclcpp::Node& node) {
   auto result = node.list_parameters({}, 10);  // depth = 10

--- a/ros2/graph_msf_ros2/package.xml
+++ b/ros2/graph_msf_ros2/package.xml
@@ -22,6 +22,8 @@
     <depend>geometry_msgs</depend>
     <depend>sensor_msgs</depend>
     <depend>std_msgs</depend>
+    <depend>std_srvs</depend>
+    <depend>visualization_msgs</depend>
     <depend>tf2</depend>
     <depend>tf2_ros</depend>
     <!-- <depend>tf2_geometry_msgs</depend> -->

--- a/ros2/graph_msf_ros2/src/lib/GraphMsfRos2.cpp
+++ b/ros2/graph_msf_ros2/src/lib/GraphMsfRos2.cpp
@@ -4,6 +4,7 @@
 // ROS2
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2_ros/transform_broadcaster.h>
+#include <shared_mutex>
 #include <std_srvs/srv/trigger.hpp>
 
 // Workspace
@@ -135,7 +136,7 @@ void GraphMsfRos2::initializeSubscribers() {
   RCLCPP_INFO(this->get_logger(), "Initializing subscribers.");
 
   // Imu
-  subImu_ = this->create_subscription<sensor_msgs::msg::Imu>("/imu_topic", rclcpp::QoS(ROS_QUEUE_SIZE).best_effort(),
+  subImu_ = this->create_subscription<sensor_msgs::msg::Imu>(imuTopic_, rclcpp::QoS(ROS_QUEUE_SIZE).best_effort(),
                                                              std::bind(&GraphMsfRos2::imuCallback, this, std::placeholders::_1));
 
   RCLCPP_INFO(this->get_logger(), "GraphMsfRos2 Initialized main IMU subscriber with topic: %s", subImu_->get_topic_name());
@@ -488,6 +489,8 @@ void GraphMsfRos2::publishState(
 void GraphMsfRos2::publishTfTransforms(const std::shared_ptr<graph_msf::SafeIntegratedNavState>& integratedNavStatePtr) {
   // Time
   const double& timeK = integratedNavStatePtr->getTimeK();  // Alias
+
+  std::shared_lock<std::shared_mutex> lock(staticTransformsPtr_->mutex());
 
   // B_O
   Eigen::Isometry3d T_B_Ok =

--- a/ros2/graph_msf_ros2/src/lib/declareRosParams.cpp
+++ b/ros2/graph_msf_ros2/src/lib/declareRosParams.cpp
@@ -28,6 +28,9 @@ void GraphMsfRos2::declareRosParams() {
   this->declare_parameter("sensor_params.imuTimeOffset", 0.0);
   this->declare_parameter("sensor_params.isImuAccInG", false);  // If true, the IMU acceleration is in g, otherwise in m/s^2
 
+  // Topics
+  this->declare_parameter("topics.imu", std::string(""));
+
   // Initialization Params
   this->declare_parameter("initialization_params.estimateGravityFromImu", false);
   this->declare_parameter("initialization_params.gravityMagnitude", 9.80665);

--- a/ros2/graph_msf_ros2/src/lib/readParams.cpp
+++ b/ros2/graph_msf_ros2/src/lib/readParams.cpp
@@ -141,6 +141,12 @@ void GraphMsfRos2::readParams() {
   graphConfigPtr_->logLatencyAndUpdateDurationToMemoryFlag_ =
       tryGetParam<bool>(this, "common_params.logLatencyAndUpdateDurationToMemory");
 
+  // Topics
+  imuTopic_ = tryGetParam<std::string>(this, "topics.imu");
+  if (imuTopic_.empty() || imuTopic_ == "__REQUIRED__" || imuTopic_ == "TODO") {
+    throw std::runtime_error("GraphMsfRos2: topics.imu must be set (empty/placeholder).");
+  }
+
   // Set frames
   staticTransformsPtr_->setWorldFrame(tryGetParam<std::string>(this, "extrinsics.worldFrame"));
   staticTransformsPtr_->setOdomFrame(tryGetParam<std::string>(this, "extrinsics.odomFrame"));

--- a/ros2/graph_msf_ros2/src/lib/readParams.cpp
+++ b/ros2/graph_msf_ros2/src/lib/readParams.cpp
@@ -161,6 +161,10 @@ void GraphMsfRos2::readParams() {
   // Logging path
   if (graphConfigPtr_->useAdditionalSlowBatchSmootherFlag_) {
     optimizationResultLoggingPath = tryGetParam<std::string>(this, "launch.optimizationResultLoggingPath");
+    if (optimizationResultLoggingPath.empty()) {
+      throw std::runtime_error(
+          "GraphMsfRos2: launch.optimizationResultLoggingPath must be non-empty when graph_params.useAdditionalSlowBatchSmoother=true.");
+    }
 
     if (optimizationResultLoggingPath.back() != '/') {
       optimizationResultLoggingPath += "/";


### PR DESCRIPTION
## Summary
- Require topics.imu param in GraphMsfRos2 and use it for the IMU subscriber.
- Add shared mutex access for static transforms to avoid TF publish races.
- Silence REGULAR_COUT redefinition warnings.
