### PR TITLE
add needed inline

### DIFF
--- a/graph_msf/include/graph_msf/geometry/conversions.h
+++ b/graph_msf/include/graph_msf/geometry/conversions.h
@@ -15,7 +15,7 @@ namespace graph_msf {
  * @param covGtsam The 6x6 covariance matrix in GTSAM convention.
  * @return The 6x6 covariance matrix in ROS convention.
  */
-Eigen::Matrix<double, 6, 6> convertCovarianceGtsamConventionToRosConvention(const Eigen::Matrix<double, 6, 6>& covGtsam) {
+inline Eigen::Matrix<double, 6, 6> convertCovarianceGtsamConventionToRosConvention(const Eigen::Matrix<double, 6, 6>& covGtsam) {
   Eigen::Matrix<double, 6, 6> covRos;
   covRos.setZero();
   covRos.block<3, 3>(0, 0) = covGtsam.block<3, 3>(3, 3);


### PR DESCRIPTION
This pull request makes a minor change to the `convertCovarianceGtsamConventionToRosConvention` function in the `geometry/conversions.h` file. The function is now marked as `inline`, which can help with performance by allowing the compiler to optimize calls to this function.

* Marked the `convertCovarianceGtsamConventionToRosConvention` function as `inline` in `geometry/conversions.h` to potentially improve performance.