### PR TITLE
graph_msf: local velocity unary for moving (non-rigid) sensor frames

### DIFF
--- a/graph_msf/include/graph_msf/factors/gmsf_expression/GmsfUnaryExpression.h
+++ b/graph_msf/include/graph_msf/factors/gmsf_expression/GmsfUnaryExpression.h
@@ -10,6 +10,8 @@ Please see the LICENSE file that has been included as part of this package.
 
 // GTSAM
 #include <gtsam/base/types.h>
+#include <gtsam/linear/NoiseModel.h>
+#include <gtsam/navigation/NavState.h>
 #include <gtsam/nonlinear/expressions.h>
 #include <gtsam/slam/BetweenFactor.h>
 #include <gtsam/slam/PriorFactor.h>

--- a/graph_msf/include/graph_msf/factors/gmsf_expression/GmsfUnaryExpressionLocalVelocity3.h
+++ b/graph_msf/include/graph_msf/factors/gmsf_expression/GmsfUnaryExpressionLocalVelocity3.h
@@ -47,6 +47,20 @@ class GmsfUnaryExpressionLocalVelocity3 final : public GmsfUnaryExpressionLocal<
     angularVelocity_ = imuMeasurement.angularVelocity;
   }
 
+  // Constructor with explicitly provided angular velocity (IMU frame), for callers that already hold
+  // the IMU sample consistent with the measurement (e.g. from a synchronized sensor tuple). Skips the
+  // IMU buffer lookup; the lever-arm term is always corrected by the estimated gyroscope bias.
+  GmsfUnaryExpressionLocalVelocity3(const std::shared_ptr<UnaryMeasurementXD<Eigen::Vector3d, 3>>& velocityUnaryMeasurementPtr,
+                                    const std::string& imuFrameName, const Eigen::Isometry3d& T_I_sensorFrame,
+                                    const Eigen::Vector3d& angularVelocity)
+      : GmsfUnaryExpressionLocal(velocityUnaryMeasurementPtr, imuFrameName, T_I_sensorFrame),
+        velocityUnaryMeasurementPtr_(velocityUnaryMeasurementPtr),
+        angularVelocity_(angularVelocity),
+        foundImuMeasurementFlag_(true),
+        exp_sensorFrame_v_fixedFrame_sensorFrame_(gtsam::Point3::Identity()),
+        exp_R_fixedFrame_I_(gtsam::Rot3::Identity()),
+        exp_I_w_W_I_(gtsam::Point3(gtsam::Point3::Zero())) {}
+
   // Destructor
   ~GmsfUnaryExpressionLocalVelocity3() = default;
 

--- a/graph_msf/include/graph_msf/factors/gmsf_expression/GmsfUnaryExpressionLocalVelocity3.h
+++ b/graph_msf/include/graph_msf/factors/gmsf_expression/GmsfUnaryExpressionLocalVelocity3.h
@@ -11,10 +11,12 @@ Please see the LICENSE file that has been included as part of this package.
 // GTSAM
 #include <gtsam/base/types.h>
 #include <gtsam/inference/Symbol.h>
+#include <gtsam/navigation/ImuBias.h>
 #include <gtsam/slam/expressions.h>
 
 // Workspace
 #include "graph_msf/factors/gmsf_expression/GmsfUnaryExpressionLocal.h"
+#include "graph_msf/imu/ImuBuffer.hpp"
 #include "graph_msf/measurements/UnaryMeasurementXD.h"
 
 namespace graph_msf {
@@ -28,12 +30,15 @@ class GmsfUnaryExpressionLocalVelocity3 final : public GmsfUnaryExpressionLocal<
       : GmsfUnaryExpressionLocal(velocityUnaryMeasurementPtr, imuFrameName, T_I_sensorFrame),
         velocityUnaryMeasurementPtr_(velocityUnaryMeasurementPtr),
         exp_sensorFrame_v_fixedFrame_sensorFrame_(gtsam::Point3::Identity()),
-        exp_R_fixedFrame_I_(gtsam::Rot3::Identity()) {
+        exp_R_fixedFrame_I_(gtsam::Rot3::Identity()),
+        exp_I_w_W_I_(gtsam::Point3(gtsam::Point3::Zero())) {
     // Find Angular Velocity in IMU Buffer which is closest to the measurement time
     // Check whether we can find an IMU measurement corresponding to the velocity measurement
     double imuTimestamp;
     graph_msf::ImuMeasurement imuMeasurement = graph_msf::ImuMeasurement();
-    if (!imuBufferPtr->getClosestImuMeasurement(imuTimestamp, imuMeasurement, 0.1, velocityUnaryMeasurementPtr->timeK())) { // previously 0.02
+    foundImuMeasurementFlag_ =
+        imuBufferPtr->getClosestImuMeasurement(imuTimestamp, imuMeasurement, 0.1, velocityUnaryMeasurementPtr->timeK()); // previously 0.02
+    if (!foundImuMeasurementFlag_) {
       REGULAR_COUT << RED_START << " No IMU Measurement (in time interval) found, assuming 0 angular velocity for the factor." << COLOR_END
                    << std::endl;
     }
@@ -69,6 +74,17 @@ class GmsfUnaryExpressionLocalVelocity3 final : public GmsfUnaryExpressionLocal<
     // Express velocity in sensor frame
     exp_sensorFrame_v_fixedFrame_sensorFrame_ =
         gtsam::rotate(inverseRot3(exp_R_fixedFrame_I_), exp_fixedFrame_v_fixedFrame_sensorFrame_);  // I_v_W_I at this point
+
+    // Angular velocity corrected by the estimated gyroscope bias --> makes the bias observable
+    // through the lever-arm term in transformImuStateToSensorFrameState()
+    if (foundImuMeasurementFlag_) {
+      const gtsam::Expression<gtsam::imuBias::ConstantBias> exp_imuBias(gtsam::symbol_shorthand::B(closestGeneralKey));
+      exp_I_w_W_I_ = gtsam::Point3_(exp_imuBias, &gtsam::imuBias::ConstantBias::correctGyroscope, gtsam::Point3_(angularVelocity_));
+    } else {
+      // No gyro sample --> keep the assumed zero angular velocity; subtracting the bias from it
+      // would inject a spurious -bias x leverArm term
+      exp_I_w_W_I_ = gtsam::Point3_(angularVelocity_);
+    }
   }
 
   // iii) Transform Measurement to Core Imu Frame
@@ -76,13 +92,9 @@ class GmsfUnaryExpressionLocalVelocity3 final : public GmsfUnaryExpressionLocal<
     // Get relative translation
     Eigen::Vector3d I_t_I_sensorFrame = T_I_sensorFrameInit_.translation();
 
-    // Angular velocity in the sensor frame
-    // TODO: Add angular velocity bias
-    gtsam::Point3_ I_w_W_I(angularVelocity_);
-
-    // Compute Velocity of the Sensor Frame with Angular Velocity
+    // Compute Velocity of the Sensor Frame with (bias-corrected) Angular Velocity
     exp_sensorFrame_v_fixedFrame_sensorFrame_ =
-        exp_sensorFrame_v_fixedFrame_sensorFrame_ + gtsam::cross(I_w_W_I, I_t_I_sensorFrame);  // I_v_W_sensorFrame at this point
+        exp_sensorFrame_v_fixedFrame_sensorFrame_ + gtsam::cross(exp_I_w_W_I_, I_t_I_sensorFrame);  // I_v_W_sensorFrame at this point
 
     // Get Rotation from Sensor Frame to Inertial Frame
     gtsam::Rot3 R_sensorFrame_I = gtsam::Rot3(T_I_sensorFrameInit_.rotation().inverse());
@@ -114,10 +126,12 @@ class GmsfUnaryExpressionLocalVelocity3 final : public GmsfUnaryExpressionLocal<
 
   // Angular Velocity
   gtsam::Point3 angularVelocity_;  // Angular Velocity
+  bool foundImuMeasurementFlag_ = false;
 
   // Expression
   gtsam::Expression<gtsam::Point3> exp_sensorFrame_v_fixedFrame_sensorFrame_;  // Translation
   gtsam::Expression<gtsam::Rot3> exp_R_fixedFrame_I_;                          // Rotation
+  gtsam::Expression<gtsam::Point3> exp_I_w_W_I_;                               // Bias-corrected Angular Velocity
 };
 }  // namespace graph_msf
 

--- a/graph_msf/include/graph_msf/interface/GraphMsfHolistic.h
+++ b/graph_msf/include/graph_msf/interface/GraphMsfHolistic.h
@@ -33,6 +33,11 @@ class GraphMsfHolistic : virtual public GraphMsf {
   void addUnaryVelocity3AbsoluteMeasurement(UnaryMeasurementXDAbsolute<Eigen::Vector3d, 3>& R_v_R_S) override;
   //// Local Measurements: Fully Local
   void addUnaryVelocity3LocalMeasurement(UnaryMeasurementXD<Eigen::Vector3d, 3>& S_v_F_S) override;
+  //// Local Measurements: Sensor frame not rigidly attached to the IMU (e.g. a kinematic contact point).
+  //// T_I_sensorFrame rotation sets the residual axes (measurement and its noise density share them),
+  //// its translation is the lever arm; I_w_W_I is the angular velocity sample of the measurement.
+  void addUnaryVelocity3LocalMovingFrameMeasurement(UnaryMeasurementXD<Eigen::Vector3d, 3>& S_v_F_S,
+                                                    const Eigen::Isometry3d& T_I_sensorFrame, const Eigen::Vector3d& I_w_W_I);
 
   /// Landmark Measurements: No systematic drift
   void addUnaryPosition3LandmarkMeasurement(UnaryMeasurementXDLandmark<Eigen::Vector3d, 3>& S_t_S_L,

--- a/graph_msf/src/lib/GraphMsfHolistic.cpp
+++ b/graph_msf/src/lib/GraphMsfHolistic.cpp
@@ -149,6 +149,41 @@ void GraphMsfHolistic::addUnaryVelocity3LocalMeasurement(UnaryMeasurementXD<Eige
   }
 }
 
+// Velocity3 in Body Frame, sensor frame not rigidly attached to the IMU
+void GraphMsfHolistic::addUnaryVelocity3LocalMovingFrameMeasurement(UnaryMeasurementXD<Eigen::Vector3d, 3>& S_v_F_S,
+                                                                    const Eigen::Isometry3d& T_I_sensorFrame,
+                                                                    const Eigen::Vector3d& I_w_W_I) {
+  // Valid measurement received
+  if (!validFirstMeasurementReceivedFlag_) {
+    validFirstMeasurementReceivedFlag_ = true;
+  }
+
+  // Only take actions if graph has been initialized
+  if (!initedGraphFlag_) {  // Case 1: Graph not yet initialized
+    return;
+  } else {  // Case 2: Graph Initialized
+    // Check for covariance violation
+    bool covarianceViolatedFlag = isCovarianceViolated_<3>(S_v_F_S.unaryMeasurementNoiseDensity(), S_v_F_S.covarianceViolationThreshold());
+    if (checkAndPrintCovarianceViolation_(S_v_F_S.measurementName(), covarianceViolatedFlag)) {
+      return;
+    }
+
+    // Create GMSF expression, with the caller-supplied extrinsics and angular velocity
+    auto gmsfUnaryExpressionVelocity3SensorFramePtr = std::make_shared<GmsfUnaryExpressionLocalVelocity3>(
+        std::make_shared<UnaryMeasurementXD<Eigen::Vector3d, 3>>(S_v_F_S), staticTransformsPtr_->getImuFrame(), T_I_sensorFrame, I_w_W_I);
+
+    // Add factor to graph
+    graphMgrPtr_->addUnaryGmsfExpressionFactor<GmsfUnaryExpressionLocalVelocity3>(gmsfUnaryExpressionVelocity3SensorFramePtr);
+
+    // Optimize ---------------------------------------------------------------
+    {
+      // Mutex for optimizeGraph Flag
+      const std::lock_guard<std::mutex> optimizeGraphLock(optimizeGraphMutex_);
+      optimizeGraphFlag_ = true;
+    }
+  }
+}
+
 // Landmark Measurements: No systematic drift ------------------------------------------------------
 // Position3
 void GraphMsfHolistic::addUnaryPosition3LandmarkMeasurement(UnaryMeasurementXDLandmark<Eigen::Vector3d, 3>& S_t_S_L,


### PR DESCRIPTION
## What

Adds `GraphMsfHolistic::addUnaryVelocity3LocalMovingFrameMeasurement`: a local Velocity3 unary for a
sensor frame that is **not rigidly attached to the IMU** — e.g. a kinematic contact point on a legged
robot, whose pose relative to the IMU changes with the joint configuration.

The existing entry point resolves `T_I_sensorFrame` by name from the static-transforms registry, which
restricts local velocity measurements to rigidly mounted sensors. The expression factor itself is already
general (it holds its transform per instance); this PR exposes that generality:

- the caller supplies the frame's current pose w.r.t. the IMU per measurement. Its rotation sets the
  residual axes (the measurement and its noise density are expressed in them), its translation is the
  lever arm;
- the caller supplies the angular velocity sample (IMU frame) consistent with the measurement, via a new
  factor constructor, instead of the factor re-fetching the closest IMU-buffer sample (which can be a
  different sample up to the 0.1 s search window — at a large lever arm that mismatch masquerades as
  velocity error);
- the lever-arm term `(omega - b_g) x t` is corrected by the estimated gyroscope bias (#38), so a large,
  time-varying lever arm makes the gyro bias observable to these measurements instead of corrupting them.

Example use case: a planted-foot (zero world-velocity) contact constraint fed as a velocity unary at a
base-axes frame anchored at the contact point — the measurement then carries only the joint-motion
velocity, and the `omega x p_contact` term stays inside the optimization on `B(k)`.

## Notes

No behavior change for existing callers: the name-resolved entry point and the IMU-buffer-lookup
constructor are untouched.

## Verification

Downstream expression-factor tests (same suite as #38): the explicit-omega constructor produces a factor
with identical unwhitened error and keys (including `B(k)`) as the buffer-lookup constructor given the
same sample; residual shifts by exactly `(omega - b_g) x t` under a gyro-bias change.

Deployed in our legged-robot stack behind a feature flag for contact-velocity fusion. On a 15 min bag
replay the run with these factors enabled stayed clean and kept the gyro bias stable, where the baseline
(feedforward bias correction outside the graph) diverged at the same point in the bag on repeated runs.
