### PR TITLE
Fix Graph-MSF factor timing gaps

### DIFF
--- a/graph_msf/CMakeLists.txt
+++ b/graph_msf/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(graph_msf)
 
+include(CTest)
+
 message("Building ${PROJECT_NAME} library -----------------------------")
 
 ## Compile as C++17, supported in ROS Noetic and newer
@@ -86,6 +88,14 @@ if (cmake_clang_tools_FOUND AND NOT DEFINED NO_CLANG_TOOLING)
         CT_HEADER_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
         CF_FIX
     )
+endif()
+
+if(BUILD_TESTING)
+    find_package(GTest REQUIRED)
+    add_executable(time_graph_key_buffer_test test/TimeGraphKeyBufferTest.cpp src/lib/TimeGraphKeyBuffer.cpp)
+    target_include_directories(time_graph_key_buffer_test PRIVATE include)
+    target_link_libraries(time_graph_key_buffer_test PRIVATE gtsam GTest::gtest_main)
+    add_test(NAME time_graph_key_buffer_test COMMAND time_graph_key_buffer_test)
 endif()
 
 #############

--- a/graph_msf/include/graph_msf/core/GraphManager.h
+++ b/graph_msf/include/graph_msf/core/GraphManager.h
@@ -9,8 +9,13 @@ Please see the LICENSE file that has been included as part of this package.
 #define GRAPH_MANAGER_HPP
 
 // C++
+#include <atomic>
 #include <chrono>
+#include <cstdint>
+#include <functional>
+#include <map>
 #include <mutex>
+#include <string>
 #include <vector>
 
 // GTSAM
@@ -41,6 +46,14 @@ Please see the LICENSE file that has been included as part of this package.
 
 namespace graph_msf {
 
+enum class UnaryFactorKeyStatus { Ready, Future, Rejected };
+
+struct UnaryFactorStatistics {
+  std::uint64_t added = 0;
+  std::uint64_t deferred = 0;
+  std::uint64_t rejected = 0;
+};
+
 /**
  * @brief GraphManager class
  * @details The GraphManager class is the central class of the GraphMSF library. It manages the graph, the optimization, and the
@@ -51,6 +64,10 @@ class GraphManager {
  public:
   GraphManager(std::shared_ptr<GraphConfig> graphConfigPtr, std::string imuFrame, std::string worldFrame);
   ~GraphManager() {
+    const UnaryFactorStatistics unaryFactorStatistics = getUnaryFactorStatistics();
+    std::cout << YELLOW_START << "GraphMSF: GraphManager" << COLOR_END << " Unary factor summary: added="
+              << unaryFactorStatistics.added << ", deferred=" << unaryFactorStatistics.deferred
+              << ", rejected=" << unaryFactorStatistics.rejected << "." << std::endl;
     std::cout << YELLOW_START << "GraphMSF: GraphManager" << GREEN_START << " Destructor called." << COLOR_END << std::endl;
     if (graphConfigPtr_->useAdditionalSlowBatchSmootherFlag_) {
       std::cout << YELLOW_START << "GraphMSF: GraphManager" << COLOR_END
@@ -65,24 +82,27 @@ class GraphManager {
   bool initPoseVelocityBiasGraph(double timeStamp, const gtsam::Pose3& T_W_I0, const gtsam::Pose3& T_O_I0);
 
   // IMU at the core -----------------------------------------------------------
-  void addImuFactorAndGetState(SafeIntegratedNavState& returnPreIntegratedNavState,
-                               std::shared_ptr<SafeNavStateWithCovarianceAndBias>& newOptimizedNavStatePtr,
-                               const std::shared_ptr<ImuBuffer>& imuBufferPtr, double imuTimeK, bool createNewStateFlag);
+  std::size_t addImuFactorAndGetState(SafeIntegratedNavState& returnPreIntegratedNavState,
+                                      std::shared_ptr<SafeNavStateWithCovarianceAndBias>& newOptimizedNavStatePtr,
+                                      const std::shared_ptr<ImuBuffer>& imuBufferPtr, double imuTimeK, bool createNewStateFlag);
 
   // All other measurements -----------------------------------------------------
 
   // Unary commodity methods --> Key Lookup
-  bool getUnaryFactorGeneralKey(gtsam::Key& returnedKey, double& returnedGraphTime, const UnaryMeasurement& unaryMeasurement);
+  UnaryFactorKeyStatus getUnaryFactorGeneralKey(gtsam::Key& returnedKey, double& returnedGraphTime,
+                                                const UnaryMeasurement& unaryMeasurement);
+  UnaryFactorKeyStatus getUnaryFactorGeneralKey(gtsam::Key& returnedKey, double& returnedGraphTime,
+                                                const std::string& measurementName, double measurementTime);
 
   // Unary Meta Method --> classic GTSAM Factors
   typedef gtsam::Key (*F)(std::uint64_t);
   template <class MEASUREMENT_TYPE, int NOISE_DIM, class FACTOR_TYPE, F SYMBOL_SHORTHAND>
-  void addUnaryFactorInImuFrame(const MEASUREMENT_TYPE& unaryMeasurement, const Eigen::Matrix<double, NOISE_DIM, 1>& unaryNoiseDensity,
-                                double measurementTime);
+  bool addUnaryFactorInImuFrame(const MEASUREMENT_TYPE& unaryMeasurement,
+                                const Eigen::Matrix<double, NOISE_DIM, 1>& unaryNoiseDensity, double measurementTime);
 
   // GMSF Holistic Graph Factors with Extrinsic Calibration ------------------------
   template <class GMSF_EXPRESSION_TYPE>
-  void addUnaryGmsfExpressionFactor(const std::shared_ptr<GMSF_EXPRESSION_TYPE> gmsfUnaryExpressionPtr,
+  bool addUnaryGmsfExpressionFactor(const std::shared_ptr<GMSF_EXPRESSION_TYPE> gmsfUnaryExpressionPtr,
                                     const bool addToOnlineSmootherFlag = true);
 
   // Robust Norm Aware Between Factor
@@ -128,6 +148,7 @@ class GraphManager {
   //  auto iterations() const { return additonalIterations_; }
   const GraphState& getOptimizedGraphState() { return optimizedGraphState_; }
   const gtsam::Key getPropagatedStateKey() { return propagatedStateKey_; }
+  UnaryFactorStatistics getUnaryFactorStatistics() const;
 
  protected:
   // Calculate state at key for graph
@@ -173,8 +194,22 @@ class GraphManager {
   void writeValueKeysToKeyTimeStampMap_(const gtsam::Values& values, double measurementTime,
                                         std::shared_ptr<std::map<gtsam::Key, double>> keyTimestampMapPtr);
 
+  void deferUnaryFactor_(double measurementTime, std::string measurementName, std::function<bool()> addFactor);
+  std::size_t addReadyDeferredUnaryFactors_();
+
   // Buffers
   std::shared_ptr<TimeGraphKeyBuffer> timeToKeyBufferPtr_;
+  struct DeferredUnaryFactor {
+    std::string measurementName;
+    std::function<bool()> addFactor;
+  };
+  std::multimap<double, DeferredUnaryFactor> deferredUnaryFactors_;
+  std::mutex deferredUnaryFactorsMutex_;
+  static constexpr std::size_t kMaxDeferredUnaryFactors_ = 100;
+  static constexpr double kMaxDeferredUnaryFactorFutureSeconds_ = 1.0;
+  std::atomic<std::uint64_t> unaryFactorsAdded_{0};
+  std::atomic<std::uint64_t> unaryFactorsDeferred_{0};
+  std::atomic<std::uint64_t> unaryFactorsRejected_{0};
 
   // Optimization Transformations
   std::string imuFrame_;

--- a/graph_msf/include/graph_msf/core/GraphManager.inl
+++ b/graph_msf/include/graph_msf/core/GraphManager.inl
@@ -13,22 +13,25 @@ namespace graph_msf {
 // 1) Unary meta method --> classic GTSAM Factors ----------------------------------------
 typedef gtsam::Key (*F)(std::uint64_t);
 template <class MEASUREMENT_TYPE, int NOISE_DIM, class FACTOR_TYPE, F SYMBOL_SHORTHAND>
-void GraphManager::addUnaryFactorInImuFrame(const MEASUREMENT_TYPE& unaryMeasurement,
-                                            const Eigen::Matrix<double, NOISE_DIM, 1>& unaryNoiseDensity, const double measurementTime) {
+bool GraphManager::addUnaryFactorInImuFrame(const MEASUREMENT_TYPE& unaryMeasurement,
+                                            const Eigen::Matrix<double, NOISE_DIM, 1>& unaryNoiseDensity,
+                                            const double measurementTime) {
   // Find the closest key in existing graph
   double closestGraphTime;
   gtsam::Key closestKey;
-  std::string callingName = "GnssPositionUnaryFactor";
-  if (!timeToKeyBufferPtr_->getClosestKeyAndTimestamp(closestGraphTime, closestKey, callingName, graphConfigPtr_->maxSearchDeviation_,
-                                                      measurementTime)) {
-    if (propagatedStateTime_ - measurementTime < 0.0) {  // Factor is coming from the future, hence add it to the buffer and adding it later
-      // TODO: Add to buffer and return --> still add it until we are there
-    } else {  // Otherwise do not add it
-      REGULAR_COUT << RED_START << " Time deviation of " << typeid(FACTOR_TYPE).name() << " at key " << closestKey << " is "
-                   << 1000 * std::abs(closestGraphTime - measurementTime) << " ms, being larger than admissible deviation of "
-                   << 1000 * graphConfigPtr_->maxSearchDeviation_ << " ms. Not adding to graph." << COLOR_END << std::endl;
-      return;
-    }
+  const std::string callingName = typeid(FACTOR_TYPE).name();
+  const UnaryFactorKeyStatus keyStatus =
+      getUnaryFactorGeneralKey(closestKey, closestGraphTime, callingName, measurementTime);
+  if (keyStatus == UnaryFactorKeyStatus::Future) {
+    deferUnaryFactor_(measurementTime, callingName, [this, unaryMeasurement, unaryNoiseDensity, measurementTime]() {
+      return addUnaryFactorInImuFrame<MEASUREMENT_TYPE, NOISE_DIM, FACTOR_TYPE, SYMBOL_SHORTHAND>(
+          unaryMeasurement, unaryNoiseDensity, measurementTime);
+    });
+    return false;
+  }
+  if (keyStatus == UnaryFactorKeyStatus::Rejected) {
+    ++unaryFactorsRejected_;
+    return false;
   }
 
   // Create noise model
@@ -42,14 +45,21 @@ void GraphManager::addUnaryFactorInImuFrame(const MEASUREMENT_TYPE& unaryMeasure
   } else {  // Case 2: No expression factor
     unaryFactorPtr = std::make_shared<FACTOR_TYPE>(SYMBOL_SHORTHAND(closestKey), unaryMeasurement, noise);
     // Write to graph
-    addFactorSafelyToRtAndBatchGraph_<const FACTOR_TYPE*>(unaryFactorPtr.get(), measurementTime);
+    const bool success = addFactorSafelyToRtAndBatchGraph_<const FACTOR_TYPE*>(unaryFactorPtr.get(), measurementTime);
+    if (!success) {
+      ++unaryFactorsRejected_;
+      return false;
+    }
   }
+
+  ++unaryFactorsAdded_;
 
   // Print summary
   if (graphConfigPtr_->verboseLevel_ > 1) {
     REGULAR_COUT << " Current propagated key " << propagatedStateKey_ << GREEN_START << ", " << typeid(FACTOR_TYPE).name()
                  << " factor added to key " << closestKey << COLOR_END << std::endl;
   }
+  return true;
 }
 
 // 2) GMSF Holistic Graph Factors with Extrinsic Calibration ------------------------
@@ -61,7 +71,7 @@ void GraphManager::addUnaryFactorInImuFrame(const MEASUREMENT_TYPE& unaryMeasure
  * @tparam GMSF_EXPRESSION_TYPE Type of the GMSF expression (e.g. GmsfUnaryExpressionAbsolutePose3).
  */
 template <class GMSF_EXPRESSION_TYPE>  // e.g. GmsfUnaryExpressionAbsolutePose3
-void GraphManager::addUnaryGmsfExpressionFactor(const std::shared_ptr<GMSF_EXPRESSION_TYPE> gmsfUnaryExpressionPtr,
+bool GraphManager::addUnaryGmsfExpressionFactor(const std::shared_ptr<GMSF_EXPRESSION_TYPE> gmsfUnaryExpressionPtr,
                                                 const bool addToOnlineSmootherFlag) {
   // Measurement
   const auto& unaryMeasurement = *gmsfUnaryExpressionPtr->getGmsfBaseUnaryMeasurementPtr();
@@ -69,8 +79,17 @@ void GraphManager::addUnaryGmsfExpressionFactor(const std::shared_ptr<GMSF_EXPRE
   // Get corresponding key of robot state in graph
   gtsam::Key closestGeneralKey;
   double closestGeneralKeyTime;
-  if (!getUnaryFactorGeneralKey(closestGeneralKey, closestGeneralKeyTime, unaryMeasurement)) {
-    return;
+  const UnaryFactorKeyStatus keyStatus = getUnaryFactorGeneralKey(closestGeneralKey, closestGeneralKeyTime, unaryMeasurement);
+  if (keyStatus == UnaryFactorKeyStatus::Future) {
+    deferUnaryFactor_(unaryMeasurement.timeK(), unaryMeasurement.measurementName(),
+                      [this, gmsfUnaryExpressionPtr, addToOnlineSmootherFlag]() {
+                        return addUnaryGmsfExpressionFactor<GMSF_EXPRESSION_TYPE>(gmsfUnaryExpressionPtr, addToOnlineSmootherFlag);
+                      });
+    return false;
+  }
+  if (keyStatus == UnaryFactorKeyStatus::Rejected) {
+    ++unaryFactorsRejected_;
+    return false;
   }
 
   // Create Expression --> exact type of expression is determined by the template
@@ -117,10 +136,11 @@ void GraphManager::addUnaryGmsfExpressionFactor(const std::shared_ptr<GMSF_EXPRE
   }
 
   // Operating on graph data
+  bool success = false;
   {
     const std::lock_guard<std::mutex> operateOnGraphDataLock(operateOnGraphDataMutex_);
     // A. Main expression factor: add to graph ---------------------------------------------------------------------------------------------
-    const bool success = addFactorToRtAndBatchGraph_<const gtsam::ExpressionFactor<typename GMSF_EXPRESSION_TYPE::template_type>*>(
+    success = addFactorToRtAndBatchGraph_<const gtsam::ExpressionFactor<typename GMSF_EXPRESSION_TYPE::template_type>*>(
         unaryExpressionFactorPtr.get(), gmsfUnaryExpressionPtr->getTimestamp(), "GMSF-Expression", addToOnlineSmootherFlag);
 
     // If successful
@@ -194,6 +214,12 @@ void GraphManager::addUnaryGmsfExpressionFactor(const std::shared_ptr<GMSF_EXPRE
     }
   }
 
+  if (!success) {
+    ++unaryFactorsRejected_;
+    return false;
+  }
+  ++unaryFactorsAdded_;
+
   // Print summary --------------------------------------
   if (graphConfigPtr_->verboseLevel_ >= 2) {
     REGULAR_COUT << " Current propagated key " << propagatedStateKey_ << ": expression factor of type "
@@ -203,6 +229,7 @@ void GraphManager::addUnaryGmsfExpressionFactor(const std::shared_ptr<GMSF_EXPRE
     }
     std::cout << COLOR_END << std::endl;
   }
+  return true;
 }
 
 // Private -----------------------------------------------------------------------------------------

--- a/graph_msf/include/graph_msf/core/TimeGraphKeyBuffer.h
+++ b/graph_msf/include/graph_msf/core/TimeGraphKeyBuffer.h
@@ -11,6 +11,7 @@ Please see the LICENSE file that has been included as part of this package.
 // C++
 #include <map>
 #include <mutex>
+#include <stdexcept>
 
 // GTSAM
 #include <gtsam/base/Vector.h>
@@ -23,7 +24,11 @@ typedef std::map<gtsam::Key, double> KeyToTimeMap;
 class TimeGraphKeyBuffer {
  public:
   // Constructor
-  TimeGraphKeyBuffer(const int bufferLength, const int verboseLevel) : bufferLength_(bufferLength), verboseLevel_(verboseLevel){};
+  TimeGraphKeyBuffer(const int bufferLength, const int verboseLevel) : bufferLength_(bufferLength), verboseLevel_(verboseLevel) {
+    if (bufferLength_ <= 0) {
+      throw std::invalid_argument("TimeGraphKeyBuffer: buffer length must be positive.");
+    }
+  };
 
   // Destructor
   ~TimeGraphKeyBuffer() = default;
@@ -31,9 +36,9 @@ class TimeGraphKeyBuffer {
   // Getters
   bool getClosestKeyAndTimestamp(double& tInGraph, gtsam::Key& key, const std::string& callingName, const double maxSearchDeviation,
                                  const double tK);
-  double getLatestTimestampInBuffer() const { return tLatestInBuffer_; }
-  const TimeToKeyMap& getTimeToKeyBuffer() { return timeToKeyBuffer_; }
-  const KeyToTimeMap& getKeyToTimeBuffer() { return keyToTimeBuffer_; }
+  double getLatestTimestampInBuffer() const;
+  TimeToKeyMap getTimeToKeyBuffer() const;
+  KeyToTimeMap getKeyToTimeBuffer() const;
 
   // Add to buffers
   void addToBuffer(const double ts, const gtsam::Key& key);
@@ -43,7 +48,7 @@ class TimeGraphKeyBuffer {
   TimeToKeyMap timeToKeyBuffer_;
   KeyToTimeMap keyToTimeBuffer_;
   // Mutex
-  std::mutex writeInBufferMutex_;
+  mutable std::mutex writeInBufferMutex_;
   // Verbose level
   int verboseLevel_ = 0;
   int bufferLength_ = -1;

--- a/graph_msf/package.xml
+++ b/graph_msf/package.xml
@@ -19,4 +19,6 @@
     <exec_depend>Eigen3</exec_depend>
     <exec_depend>GTSAM</exec_depend>
 
+    <test_depend>gtest</test_depend>
+
 </package>

--- a/graph_msf/src/lib/GraphManager.cpp
+++ b/graph_msf/src/lib/GraphManager.cpp
@@ -197,16 +197,17 @@ bool GraphManager::initPoseVelocityBiasGraph(const double timeStamp, const gtsam
 }
 
 // IMU at the core --------------------------------------------------------------
-void GraphManager::addImuFactorAndGetState(SafeIntegratedNavState& returnPreIntegratedNavState,
-                                           std::shared_ptr<SafeNavStateWithCovarianceAndBias>& newOptimizedNavStatePtr,
-                                           const std::shared_ptr<ImuBuffer>& imuBufferPtr, const double imuTimeK, bool createNewStateFlag) {
+std::size_t GraphManager::addImuFactorAndGetState(SafeIntegratedNavState& returnPreIntegratedNavState,
+                                                  std::shared_ptr<SafeNavStateWithCovarianceAndBias>& newOptimizedNavStatePtr,
+                                                  const std::shared_ptr<ImuBuffer>& imuBufferPtr, const double imuTimeK,
+                                                  bool createNewStateFlag) {
   // Logging of latency
   if (graphConfigPtr_->logLatencyAndUpdateDurationToMemoryFlag_) {
     latencyStartTime_ = std::chrono::high_resolution_clock::now();
   }
 
   // Looking up from IMU buffer --> acquire mutex (otherwise values for key might not be set)
-  const std::lock_guard<std::mutex> operateOnGraphDataLock(operateOnGraphDataMutex_);
+  std::unique_lock<std::mutex> operateOnGraphDataLock(operateOnGraphDataMutex_);
 
   // Part 1 (ALWAYS): Propagate state and imu measurement to pre-integrator -----------------------
   // 1.1 Get last two measurements from buffer to determine dt
@@ -328,6 +329,9 @@ void GraphManager::addImuFactorAndGetState(SafeIntegratedNavState& returnPreInte
     std::chrono::duration<double> latencyDuration = latencyEndTime_ - latencyStartTime_;
     latencyContainer_[imuTimeK] = latencyDuration.count();
   }
+
+  operateOnGraphDataLock.unlock();
+  return addReadyDeferredUnaryFactors_();
 }
 
 // Set T_W_F
@@ -341,41 +345,78 @@ bool GraphManager::setInitialWorldFrameToFixedFrameTransform(const Eigen::Isomet
 
 // Unary factors ----------------------------------------------------------------
 // Key Lookup
-bool GraphManager::getUnaryFactorGeneralKey(gtsam::Key& returnedKey, double& returnedGraphTime, const UnaryMeasurement& unaryMeasurement) {
-  // Find the closest key in existing graph
-  // Case 1: Can't add immediately
-  if (!timeToKeyBufferPtr_->getClosestKeyAndTimestamp(returnedGraphTime, returnedKey, unaryMeasurement.measurementName(),
-                                                      graphConfigPtr_->maxSearchDeviation_, unaryMeasurement.timeK())) {
-    // Measurement coming from the future
-    if (propagatedStateTime_ - unaryMeasurement.timeK() < 0.0) {  // Factor is coming from the future, hence add it to the buffer
-      // Not too far in the future --> add to buffer and add later
-      if (unaryMeasurement.timeK() - propagatedStateTime_ < 4 * graphConfigPtr_->maxSearchDeviation_) {
-        // TODO: Add to buffer and return --> still add it until we are there
-        return true;
-      }
-      // Too far in the future --> do not add it
-      else {
-        std::cout << 1000 * (propagatedStateTime_ - unaryMeasurement.timeK()) << std::endl;
-        std::cout << 1000 * (returnedGraphTime - unaryMeasurement.timeK()) << std::endl;
-        REGULAR_COUT << RED_START << " Factor coming from the future, AND time deviation of " << typeid(unaryMeasurement).name()
-                     << " at key " << returnedKey << " is " << 1000 * std::abs(returnedGraphTime - unaryMeasurement.timeK())
-                     << " ms, being larger than admissible deviation of " << 4 * 1000 * graphConfigPtr_->maxSearchDeviation_
-                     << " ms. Not adding to graph." << COLOR_END << std::endl;
-        return false;
-      }
+UnaryFactorKeyStatus GraphManager::getUnaryFactorGeneralKey(gtsam::Key& returnedKey, double& returnedGraphTime,
+                                                            const UnaryMeasurement& unaryMeasurement) {
+  return getUnaryFactorGeneralKey(returnedKey, returnedGraphTime, unaryMeasurement.measurementName(), unaryMeasurement.timeK());
+}
+
+UnaryFactorKeyStatus GraphManager::getUnaryFactorGeneralKey(gtsam::Key& returnedKey, double& returnedGraphTime,
+                                                            const std::string& measurementName, const double measurementTime) {
+  const double latestGraphTime = timeToKeyBufferPtr_->getLatestTimestampInBuffer();
+  returnedGraphTime = latestGraphTime;
+  returnedKey = 0;
+  const bool foundKey = timeToKeyBufferPtr_->getClosestKeyAndTimestamp(
+      returnedGraphTime, returnedKey, measurementName, graphConfigPtr_->maxSearchDeviation_, measurementTime);
+
+  if (measurementTime > latestGraphTime) {
+    const double futureSeconds = measurementTime - latestGraphTime;
+    if (futureSeconds <= kMaxDeferredUnaryFactorFutureSeconds_) {
+      return UnaryFactorKeyStatus::Future;
     }
-    // Measurement coming from the past, but could not find suitable key
-    else {  // Otherwise do not add it
-      REGULAR_COUT << RED_START << " Time deviation of " << typeid(unaryMeasurement).name() << " at key " << returnedKey << " is "
-                   << 1000 * std::abs(returnedGraphTime - unaryMeasurement.timeK()) << " ms, being larger than admissible deviation of "
-                   << 1000 * graphConfigPtr_->maxSearchDeviation_ << " ms. Not adding to graph." << COLOR_END << std::endl;
-      return false;
+
+    REGULAR_COUT << RED_START << " Factor '" << measurementName << "' is " << 1000.0 * futureSeconds
+                 << " ms newer than the latest graph key, exceeding the "
+                 << 1000.0 * kMaxDeferredUnaryFactorFutureSeconds_ << " ms deferred-factor window. Not adding to graph." << COLOR_END
+                 << std::endl;
+    return UnaryFactorKeyStatus::Rejected;
+  }
+
+  if (foundKey) {
+    return UnaryFactorKeyStatus::Ready;
+  }
+
+  REGULAR_COUT << RED_START << " Time deviation of factor '" << measurementName << "' at key " << returnedKey << " is "
+               << 1000.0 * std::abs(returnedGraphTime - measurementTime) << " ms, being larger than admissible deviation of "
+               << 1000.0 * graphConfigPtr_->maxSearchDeviation_ << " ms. Not adding to graph." << COLOR_END << std::endl;
+  return UnaryFactorKeyStatus::Rejected;
+}
+
+void GraphManager::deferUnaryFactor_(const double measurementTime, std::string measurementName, std::function<bool()> addFactor) {
+  const std::lock_guard<std::mutex> deferredFactorsLock(deferredUnaryFactorsMutex_);
+  if (deferredUnaryFactors_.size() >= kMaxDeferredUnaryFactors_) {
+    REGULAR_COUT << RED_START << " Deferred unary factor queue is full. Dropping oldest factor '"
+                 << deferredUnaryFactors_.begin()->second.measurementName << "'." << COLOR_END << std::endl;
+    deferredUnaryFactors_.erase(deferredUnaryFactors_.begin());
+    ++unaryFactorsRejected_;
+  }
+
+  deferredUnaryFactors_.emplace(measurementTime, DeferredUnaryFactor{std::move(measurementName), std::move(addFactor)});
+  ++unaryFactorsDeferred_;
+}
+
+std::size_t GraphManager::addReadyDeferredUnaryFactors_() {
+  const double latestGraphTime = timeToKeyBufferPtr_->getLatestTimestampInBuffer();
+  std::vector<DeferredUnaryFactor> readyFactors;
+  {
+    const std::lock_guard<std::mutex> deferredFactorsLock(deferredUnaryFactorsMutex_);
+    auto factorIterator = deferredUnaryFactors_.begin();
+    while (factorIterator != deferredUnaryFactors_.end() && factorIterator->first <= latestGraphTime) {
+      readyFactors.push_back(std::move(factorIterator->second));
+      factorIterator = deferredUnaryFactors_.erase(factorIterator);
     }
   }
-  // Case 2: Can add immediately
-  else {
-    return true;
+
+  std::size_t addedFactorCount = 0;
+  for (auto& factor : readyFactors) {
+    if (factor.addFactor()) {
+      ++addedFactorCount;
+    }
   }
+  return addedFactorCount;
+}
+
+UnaryFactorStatistics GraphManager::getUnaryFactorStatistics() const {
+  return UnaryFactorStatistics{unaryFactorsAdded_.load(), unaryFactorsDeferred_.load(), unaryFactorsRejected_.load()};
 }
 
 // Robust Aware Between factors ------------------------------------------------------------------------------------------------------

--- a/graph_msf/src/lib/GraphMsf.cpp
+++ b/graph_msf/src/lib/GraphMsf.cpp
@@ -285,8 +285,13 @@ bool GraphMsf::addCoreImuMeasurementAndGetState(
   // Only create state every n-th measurements (or at first successful iteration)
   bool createNewStateFlag = imuCallbackCounter_ % graphConfigPtr_->createStateEveryNthImuMeasurement_ == 0 || !normalOperationFlag_;
   // Add IMU factor and return propagated & optimized state
-  graphMgrPtr_->addImuFactorAndGetState(*preIntegratedNavStatePtr_, returnOptimizedStateWithCovarianceAndBiasPtr, coreImuBufferPtr_,
-                                        imuTimeK, createNewStateFlag);
+  const std::size_t addedDeferredUnaryFactors =
+      graphMgrPtr_->addImuFactorAndGetState(*preIntegratedNavStatePtr_, returnOptimizedStateWithCovarianceAndBiasPtr, coreImuBufferPtr_,
+                                            imuTimeK, createNewStateFlag);
+  if (addedDeferredUnaryFactors > 0) {
+    const std::lock_guard<std::mutex> optimizeGraphLock(optimizeGraphMutex_);
+    optimizeGraphFlag_ = true;
+  }
   returnPreIntegratedNavStatePtr = std::make_shared<SafeIntegratedNavState>(*preIntegratedNavStatePtr_);
 
   // Set to normal operation

--- a/graph_msf/src/lib/TimeGraphKeyBuffer.cpp
+++ b/graph_msf/src/lib/TimeGraphKeyBuffer.cpp
@@ -9,6 +9,9 @@ Please see the LICENSE file that has been included as part of this package.
 #include "graph_msf/core/TimeGraphKeyBuffer.h"
 #include "graph_msf/interface/Terminal.h"
 
+// C++
+#include <iterator>
+
 namespace graph_msf {
 
 void TimeGraphKeyBuffer::addToBuffer(const double ts, const gtsam::Key& key) {
@@ -17,46 +20,55 @@ void TimeGraphKeyBuffer::addToBuffer(const double ts, const gtsam::Key& key) {
               << std::setprecision(14) << ts << std::endl;
   }
 
-  // Mutex block
-  {
-    // Writing to IMU buffer --> acquire mutex
-    const std::lock_guard<std::mutex> writeInBufferLock(writeInBufferMutex_);
-    timeToKeyBuffer_[ts] = key;
-    keyToTimeBuffer_[key] = ts;
-    if (ts > tLatestInBuffer_) {
-      tLatestInBuffer_ = ts;
-    }
+  const std::lock_guard<std::mutex> writeInBufferLock(writeInBufferMutex_);
+
+  // Keep the forward and reverse maps one-to-one when a timestamp or key is replaced.
+  if (const auto existingKey = timeToKeyBuffer_.find(ts); existingKey != timeToKeyBuffer_.end()) {
+    keyToTimeBuffer_.erase(existingKey->second);
+  }
+  if (const auto existingTime = keyToTimeBuffer_.find(key); existingTime != keyToTimeBuffer_.end()) {
+    timeToKeyBuffer_.erase(existingTime->second);
   }
 
-  // If Key buffer is too large, remove first element
-  if (timeToKeyBuffer_.size() > bufferLength_) {
-    timeToKeyBuffer_.erase(timeToKeyBuffer_.begin());
-    keyToTimeBuffer_.erase(keyToTimeBuffer_.begin());
+  timeToKeyBuffer_[ts] = key;
+  keyToTimeBuffer_[key] = ts;
+
+  while (timeToKeyBuffer_.size() > static_cast<std::size_t>(bufferLength_)) {
+    const auto oldest = timeToKeyBuffer_.begin();
+    keyToTimeBuffer_.erase(oldest->second);
+    timeToKeyBuffer_.erase(oldest);
   }
+
+  tLatestInBuffer_ = timeToKeyBuffer_.rbegin()->first;
 }
 
 bool TimeGraphKeyBuffer::getClosestKeyAndTimestamp(double& tInGraph, gtsam::Key& key, const std::string& callingName,
                                                    const double maxSearchDeviation, const double tK) {
-  std::_Rb_tree_iterator<std::pair<const double, gtsam::Key>> upperIterator;
+  double latestTimestamp = 0.0;
   {
-    // Read from IMU buffer --> acquire mutex
     const std::lock_guard<std::mutex> writeInBufferLock(writeInBufferMutex_);
-    upperIterator = timeToKeyBuffer_.upper_bound(tK);
+    if (timeToKeyBuffer_.empty()) {
+      std::cerr << YELLOW_START << "GMsf-TimeKeyBuffer " << RED_START << "called from " << callingName << ": Buffer is empty!"
+                << COLOR_END << std::endl;
+      return false;
+    }
+
+    const auto upperIterator = timeToKeyBuffer_.upper_bound(tK);
+    TimeToKeyMap::const_iterator closestIterator;
+    if (upperIterator == timeToKeyBuffer_.begin()) {
+      closestIterator = upperIterator;
+    } else if (upperIterator == timeToKeyBuffer_.end()) {
+      closestIterator = std::prev(timeToKeyBuffer_.end());
+    } else {
+      const auto lowerIterator = std::prev(upperIterator);
+      closestIterator = std::abs(tK - lowerIterator->first) < std::abs(upperIterator->first - tK) ? lowerIterator : upperIterator;
+    }
+
+    tInGraph = closestIterator->first;
+    key = closestIterator->second;
+    latestTimestamp = tLatestInBuffer_;
   }
 
-  // Empty buffer
-  if (timeToKeyBuffer_.empty()) {
-    std::cerr << YELLOW_START << "GMsf-TimeKeyBuffer " << RED_START << "called from " << callingName << ": Buffer is empty!" << COLOR_END
-              << std::endl;
-    return false;
-  }
-
-  auto lowerIterator = upperIterator;
-  --lowerIterator;
-
-  // Keep key which is closer to tLidar
-  tInGraph = std::abs(tK - lowerIterator->first) < std::abs(upperIterator->first - tK) ? lowerIterator->first : upperIterator->first;
-  key = std::abs(tK - lowerIterator->first) < std::abs(upperIterator->first - tK) ? lowerIterator->second : upperIterator->second;
   double timeDeviation = tInGraph - tK;
 
   if (verboseLevel_ >= 2) {
@@ -66,8 +78,8 @@ bool TimeGraphKeyBuffer::getClosestKeyAndTimestamp(double& tInGraph, gtsam::Key&
               << " found time step: " << tInGraph << " at key " << key << std::endl;
     std::cout << YELLOW_START << "GMsf-TimeKeyBuffer" << COLOR_END << " Time Deviation (t_graph-t_request): " << 1000 * timeDeviation
               << " ms" << std::endl;
-    std::cout << YELLOW_START << "GMsf-TimeKeyBuffer" << COLOR_END << " Latest IMU timestamp: " << tLatestInBuffer_
-              << ", hence absolut delay of measurement is " << 1000 * (tLatestInBuffer_ - tK) << "ms." << std::endl;
+    std::cout << YELLOW_START << "GMsf-TimeKeyBuffer" << COLOR_END << " Latest IMU timestamp: " << latestTimestamp
+              << ", hence absolut delay of measurement is " << 1000 * (latestTimestamp - tK) << "ms." << std::endl;
   }
 
   // Check for error and warn user
@@ -76,6 +88,21 @@ bool TimeGraphKeyBuffer::getClosestKeyAndTimestamp(double& tInGraph, gtsam::Key&
   }
 
   return true;
+}
+
+double TimeGraphKeyBuffer::getLatestTimestampInBuffer() const {
+  const std::lock_guard<std::mutex> writeInBufferLock(writeInBufferMutex_);
+  return tLatestInBuffer_;
+}
+
+TimeToKeyMap TimeGraphKeyBuffer::getTimeToKeyBuffer() const {
+  const std::lock_guard<std::mutex> writeInBufferLock(writeInBufferMutex_);
+  return timeToKeyBuffer_;
+}
+
+KeyToTimeMap TimeGraphKeyBuffer::getKeyToTimeBuffer() const {
+  const std::lock_guard<std::mutex> writeInBufferLock(writeInBufferMutex_);
+  return keyToTimeBuffer_;
 }
 
 }  // namespace graph_msf

--- a/graph_msf/test/TimeGraphKeyBufferTest.cpp
+++ b/graph_msf/test/TimeGraphKeyBufferTest.cpp
@@ -1,0 +1,55 @@
+#include <gtest/gtest.h>
+
+#include "graph_msf/core/TimeGraphKeyBuffer.h"
+
+namespace graph_msf {
+namespace {
+
+TEST(TimeGraphKeyBufferTest, ReturnsSafeBoundaryKeys) {
+  TimeGraphKeyBuffer buffer(3, 0);
+  buffer.addToBuffer(1.0, 10);
+  buffer.addToBuffer(2.0, 20);
+
+  double graphTime = 0.0;
+  gtsam::Key key = 0;
+
+  EXPECT_FALSE(buffer.getClosestKeyAndTimestamp(graphTime, key, "before", 0.1, 0.5));
+  EXPECT_DOUBLE_EQ(graphTime, 1.0);
+  EXPECT_EQ(key, 10);
+
+  EXPECT_TRUE(buffer.getClosestKeyAndTimestamp(graphTime, key, "near-latest", 0.1, 1.95));
+  EXPECT_DOUBLE_EQ(graphTime, 2.0);
+  EXPECT_EQ(key, 20);
+
+  EXPECT_FALSE(buffer.getClosestKeyAndTimestamp(graphTime, key, "after", 0.1, 2.5));
+  EXPECT_DOUBLE_EQ(graphTime, 2.0);
+  EXPECT_EQ(key, 20);
+}
+
+TEST(TimeGraphKeyBufferTest, EvictionAndReplacementKeepMapsConsistent) {
+  TimeGraphKeyBuffer buffer(2, 0);
+  buffer.addToBuffer(1.0, 30);
+  buffer.addToBuffer(2.0, 10);
+  buffer.addToBuffer(3.0, 20);
+
+  auto timeToKey = buffer.getTimeToKeyBuffer();
+  auto keyToTime = buffer.getKeyToTimeBuffer();
+  EXPECT_EQ(timeToKey, (TimeToKeyMap{{2.0, 10}, {3.0, 20}}));
+  EXPECT_EQ(keyToTime, (KeyToTimeMap{{10, 2.0}, {20, 3.0}}));
+
+  buffer.addToBuffer(4.0, 20);
+  buffer.addToBuffer(2.0, 99);
+
+  timeToKey = buffer.getTimeToKeyBuffer();
+  keyToTime = buffer.getKeyToTimeBuffer();
+  EXPECT_EQ(timeToKey, (TimeToKeyMap{{2.0, 99}, {4.0, 20}}));
+  EXPECT_EQ(keyToTime, (KeyToTimeMap{{20, 4.0}, {99, 2.0}}));
+  EXPECT_DOUBLE_EQ(buffer.getLatestTimestampInBuffer(), 4.0);
+}
+
+TEST(TimeGraphKeyBufferTest, RejectsNonPositiveCapacity) {
+  EXPECT_THROW(TimeGraphKeyBuffer(0, 0), std::invalid_argument);
+}
+
+}  // namespace
+}  // namespace graph_msf

--- a/ros2/graph_msf_ros2/include/graph_msf_ros2/GraphMsfRos2.h
+++ b/ros2/graph_msf_ros2/include/graph_msf_ros2/GraphMsfRos2.h
@@ -5,6 +5,8 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <queue>
@@ -196,6 +198,12 @@ class GraphMsfRos2 : public GraphMsfClassic, public GraphMsfHolistic, public rcl
   // Last Optimized State Timestamp
   double lastOptimizedStateTimestamp_ = 0.0;
   double lastIntegratedStateTimestamp_ = 0.0;
+
+  // Main IMU callback timing diagnostics
+  std::uint64_t imuMessagesReceived_ = 0;
+  std::uint64_t estimatedMissingImuMessages_ = 0;
+  double lastImuMessageTimestamp_ = std::numeric_limits<double>::quiet_NaN();
+  double maximumImuMessageGapSeconds_ = 0.0;
 
   // Non-time-critical data thread for paths, variances, markers, etc.
   std::queue<NonTimeCriticalData> nonTimeCriticalQueue_;

--- a/ros2/graph_msf_ros2/src/lib/GraphMsfRos2.cpp
+++ b/ros2/graph_msf_ros2/src/lib/GraphMsfRos2.cpp
@@ -4,12 +4,18 @@
 // ROS2
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2_ros/transform_broadcaster.h>
+#include <algorithm>
+#include <cmath>
 #include <std_srvs/srv/trigger.hpp>
 
 // Workspace
 #include "graph_msf_ros2/util/conversions.h"
 
 namespace graph_msf {
+
+namespace {
+constexpr std::size_t kImuSubscriptionQueueDepth = 100;
+}
 
 GraphMsfRos2::GraphMsfRos2(const std::string& nodeName, const rclcpp::NodeOptions& options) : Node(nodeName, options) {
   RCLCPP_INFO(this->get_logger(), "GraphMsfRos2-Constructor called.");
@@ -30,6 +36,9 @@ GraphMsfRos2::GraphMsfRos2(const std::string& nodeName, const rclcpp::NodeOption
 
 GraphMsfRos2::~GraphMsfRos2() {
   RCLCPP_INFO(this->get_logger(), "GraphMsfRos2-Destructor called.");
+  RCLCPP_INFO(this->get_logger(), "Main IMU timing summary: received=%llu, estimated_missing=%llu, maximum_gap=%.3f ms.",
+              static_cast<unsigned long long>(imuMessagesReceived_),
+              static_cast<unsigned long long>(estimatedMissingImuMessages_), 1000.0 * maximumImuMessageGapSeconds_);
 
   // Signal all threads to shutdown
   shutdownRequested_ = true;
@@ -132,7 +141,7 @@ void GraphMsfRos2::initializeSubscribers() {
   RCLCPP_INFO(this->get_logger(), "Initializing subscribers.");
 
   // Imu
-  subImu_ = this->create_subscription<sensor_msgs::msg::Imu>("/imu_topic", rclcpp::QoS(ROS_QUEUE_SIZE).best_effort(),
+  subImu_ = this->create_subscription<sensor_msgs::msg::Imu>("/imu_topic", rclcpp::QoS(kImuSubscriptionQueueDepth).best_effort(),
                                                              std::bind(&GraphMsfRos2::imuCallback, this, std::placeholders::_1));
 
   RCLCPP_INFO(this->get_logger(), "GraphMsfRos2 Initialized main IMU subscriber with topic: %s", subImu_->get_topic_name());
@@ -398,6 +407,29 @@ long GraphMsfRos2::secondsSinceStart() {
 
 // Main IMU Callback
 void GraphMsfRos2::imuCallback(const sensor_msgs::msg::Imu::SharedPtr imuMsgPtr) {
+  const double imuTimestamp = imuMsgPtr->header.stamp.sec + 1e-9 * imuMsgPtr->header.stamp.nanosec;
+  ++imuMessagesReceived_;
+  if (std::isfinite(lastImuMessageTimestamp_)) {
+    const double imuGapSeconds = imuTimestamp - lastImuMessageTimestamp_;
+    if (imuGapSeconds <= 0.0) {
+      RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
+                           "Main IMU timestamp is not strictly increasing: previous=%.9f, current=%.9f.",
+                           lastImuMessageTimestamp_, imuTimestamp);
+    } else {
+      maximumImuMessageGapSeconds_ = std::max(maximumImuMessageGapSeconds_, imuGapSeconds);
+      const double expectedPeriodSeconds = 1.0 / graphConfigPtr_->imuRate_;
+      if (imuGapSeconds > 1.5 * expectedPeriodSeconds) {
+        const auto estimatedMissing =
+            static_cast<std::uint64_t>(std::max(0LL, std::llround(imuGapSeconds / expectedPeriodSeconds) - 1));
+        estimatedMissingImuMessages_ += estimatedMissing;
+        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
+                             "Main IMU timestamp gap %.3f ms indicates approximately %llu missing sample(s).",
+                             1000.0 * imuGapSeconds, static_cast<unsigned long long>(estimatedMissing));
+      }
+    }
+  }
+  lastImuMessageTimestamp_ = imuTimestamp;
+
   // Convert to Eigen
   Eigen::Vector3d linearAcc(imuMsgPtr->linear_acceleration.x, imuMsgPtr->linear_acceleration.y, imuMsgPtr->linear_acceleration.z);
   Eigen::Vector3d angularVel(imuMsgPtr->angular_velocity.x, imuMsgPtr->angular_velocity.y, imuMsgPtr->angular_velocity.z);
@@ -408,8 +440,7 @@ void GraphMsfRos2::imuCallback(const sensor_msgs::msg::Imu::SharedPtr imuMsgPtr)
   std::shared_ptr<SafeNavStateWithCovarianceAndBias> optimizedStateWithCovarianceAndBiasPtr = nullptr;
 
   // Add measurement and get state
-  if (GraphMsf::addCoreImuMeasurementAndGetState(linearAcc, angularVel,
-                                                 imuMsgPtr->header.stamp.sec + 1e-9 * imuMsgPtr->header.stamp.nanosec,
+  if (GraphMsf::addCoreImuMeasurementAndGetState(linearAcc, angularVel, imuTimestamp,
                                                  preIntegratedNavStatePtr, optimizedStateWithCovarianceAndBiasPtr, addedImuMeasurements)) {
     // Encountered Delay
     auto now = clock_->now();


### PR DESCRIPTION
## Summary

- make TimeGraphKeyBuffer lookups thread-safe, boundary-safe, and consistently bounded
- defer near-future unary factors in a bounded queue and drain them as graph keys arrive
- increase the ROS 2 IMU subscription queue and add timestamp-gap diagnostics
- add focused TimeGraphKeyBuffer regression tests

## Validation

- time_graph_key_buffer_test: passed
- original Mole integration branch: Graph-MSF, ROS 2 wrapper, and Mole estimator built; all 86 tests passed; live robot state and map-to-base TF remained healthy
- note: a full build from current main is independently blocked by existing GTSAM API incompatibilities in untouched legacy code